### PR TITLE
add missing option to error message

### DIFF
--- a/src/credential-status-manager-github.ts
+++ b/src/credential-status-manager-github.ts
@@ -75,7 +75,7 @@ export class GithubCredentialStatusManager extends BaseCredentialStatusManager {
     const isProperlyConfigured = GITHUB_MANAGER_REQUIRED_OPTIONS.every(
       (option: keyof GithubCredentialStatusManagerOptions) => {
         if (!options[option]) {
-          missingOptions.push();
+          missingOptions.push(option);
         }
         return !!options[option];
       }


### PR DESCRIPTION
When a missing option is identified it adds it to the 'missingOptions' list so that the missing option can then be displayed in the error.  The 'push' to add the missing option just wasn't passing the actual option as an argument.