### PR TITLE
Add fault recovery mechanism

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm install
       - name: Run test with Node.js ${{ matrix.node-version }}
-        run: npm run test-node
+        run: npm run pretest && npm run test-node && npm run posttest
         env:
           CI: true
   # FIXME: fix karma tests
@@ -36,7 +36,7 @@ jobs:
   #         node-version: ${{ matrix.node-version }}
   #     - run: npm install
   #     - name: Run karma tests
-  #       run: npm run test-karma
+  #       run: npm run pretest && npm run test-karma && npm run posttest
   lint:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,11 +8,11 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
@@ -27,11 +27,11 @@ jobs:
   #   timeout-minutes: 10
   #   strategy:
   #     matrix:
-  #       node-version: [16.x]
+  #       node-version: [20.x]
   #   steps:
-  #     - uses: actions/checkout@v2
+  #     - uses: actions/checkout@v4
   #     - name: Use Node.js ${{ matrix.node-version }}
-  #       uses: actions/setup-node@v1
+  #       uses: actions/setup-node@v4
   #       with:
   #         node-version: ${{ matrix.node-version }}
   #     - run: npm install
@@ -41,11 +41,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # credential-status-manager-git Changelog
 
-## 2.0.0 - 2023-XX-23
+## 2.0.0 - 2023-XX-24
 
 ### Added
 
 - Add fault recovery mechanism.
+- Use string for status list index.
+- Add custom error classes to improve error handling.
 
 ## 1.0.0 - 2023-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # credential-status-manager-git Changelog
 
-## 2.0.0 - 2023-XX-24
+## 2.0.0 - 2024-XX-XX
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,12 @@
 ### Added
 
 - Add fault recovery mechanism.
+- Check client's authority to manage status repos during initialization.
+- Modify config and log data formats.
 - Use string for status list index.
 - Add custom error classes to improve error handling.
+- Fix test execution in GitHub workflows with pretest and posttest.
+- Add minor copy and cosmetic updates.
 
 ## 1.0.0 - 2023-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # credential-status-manager-git Changelog
 
+## 2.0.0 - 2023-XX-23
+
+### Added
+
+- Add fault recovery mechanism.
+
 ## 1.0.0 - 2023-06-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ console.log(credentialWithStatus);
     id: 'https://university-xyz.github.io/credential-status/V27UAUYPNR#1',
     type: 'StatusList2021Entry',
     statusPurpose: 'revocation',
-    statusListIndex: 1,
+    statusListIndex: '1',
     statusListCredential: 'https://university-xyz.github.io/credential-status/V27UAUYPNR'
   }
 }

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ const statusManager = await createStatusManager({
 });
 ```
 
-**Note:** A Status List 2021 credential can be found in the designated status repository (`repoName`) of the designated owner account (`ownerAccountName`) which is populated by `createStatusManager`. Additionally, relevant historical data can be found in the designated status metadata repository (`metaRepoName`) in the same owner account. Note that these repositories need to be manually created prior to calling `createStatusManager`. Finally, you can find a publicly visible version of the aforementioned Status List 2021 credential at the relevant URL for hosted sites in the source control service of choice (e.g., https://`ownerAccountName`.github.io/`repoName`/`statusListId` for GitHub, where `statusListId` is the name of a file that is automatically generated in `repoName`).
+**Note:** A Status List 2021 credential can be found in the designated status repository (`repoName`) of the designated owner account (`ownerAccountName`) which is populated by `createStatusManager`. Additionally, relevant historical data can be found in the designated status metadata repository (`metaRepoName`) in the same owner account. Note that these repositories need to be manually created prior to calling `createStatusManager`. Finally, you can find a publicly visible version of the aforementioned Status List 2021 credential at the relevant URL for hosted sites in the source control service of choice (e.g., https://`ownerAccountName`.github.io/`repoName`/`statusCredentialId` for GitHub, where `statusCredentialId` is the name of a file that is automatically generated in `repoName`).
 
 ### Allocate status for credential
 
@@ -139,7 +139,7 @@ console.log(credentialWithStatus);
 */
 ```
 
-**Note:** If the caller invokes `allocateStatus` multiple times with the same credential ID against the same instance of a credential status manager, the library will not allocate a new status list entry. It will just return a credential with the same status info as it did in the previous invocation.
+**Note:** If the caller invokes `allocateStatus` multiple times with the same credential ID against the same instance of a credential status manager, the library will not allocate a new entry. It will just return a credential with the same status info as it did in the previous invocation.
 
 ### Update status of credential
 
@@ -190,8 +190,8 @@ console.log(credentialStatus);
   credentialSubject: 'did:example:abcdef',
   credentialState: 'revoked',
   verificationMethod: 'did:key:z6MkhVTX9BF3NGYX6cc7jWpbNnR7cAjH8LUffabZP8Qu4ysC#z6MkhVTX9BF3NGYX6cc7jWpbNnR7cAjH8LUffabZP8Qu4ysC',
-  statusListId: 'V27UAUYPNR',
-  statusListIndex: 1
+  statusCredentialId: 'V27UAUYPNR',
+  credentialStatusIndex: 1
 }
 */
 ```
@@ -203,13 +203,13 @@ The `hasStatusAuthority` is an instance method that is called on a credential st
 Here is a sample call to `hasStatusAuthority` in the context of Express.js middleware:
 
 ```ts
-// retrieves status list manager
+// retrieves status credential manager
 export async function getCredentialStatusManager(req, res, next) {
   try {
     req.statusManager = await getStatusManager();
     next();
   } catch (error) {
-    return res.send('Failed to retrieve credential status list manager');
+    return res.send('Failed to retrieve credential status manager');
   }
 }
 
@@ -295,7 +295,7 @@ async function verifyStatusRepoAccess(req, res, next) {
 5. Enter a name and expiration date for the access token
 6. Select the *Maintainer* role
 7. Select the *api* scope
-8. Click the *Create personal access token* button
+8. Click the *Create project access token* button
 9. Copy the generated token
 10. Use the token as the value for `repoAccessToken` in invocations of `createStatusManager` and `hasStatusAuthority`
 11. Repeat these steps for `metaRepoName` and `metaRepoAccessToken`

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "prettier": "prettier src --write",
     "rebuild": "npm run clear && npm run build",
     "test": "npm run lint && npm run test-node",
-    "test-karma": "node pre-test.js; npm run build-test && karma start karma.conf.js && rm -rf dist/test; node post-test.js",
-    "test-node": "node pre-test.js; npm run build-test && mocha dist/test/*.spec.js && rm -rf dist/test; node post-test.js"
+    "test-karma": "npm run build-test && karma start karma.conf.js && rm -rf dist/test",
+    "test-node": "npm run build-test && mocha dist/test/*.spec.js && rm -rf dist/test"
   },
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@digitalcredentials/credential-status-manager-git",
   "description": "A Typescript library for managing the status of Verifiable Credentials in Git using Status List 2021",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "publishConfig": {
     "access": "public"
   },

--- a/post-test.js
+++ b/post-test.js
@@ -16,11 +16,11 @@ const updateTsconfig = async () => {
   fs.writeFileSync(tsconfigFilePath, JSON.stringify(tsconfigJson, null, 2));
 };
 
-// combine pre-test subscripts
+// combine post-test subscripts
 const runPostTest = async () => {
   await updatePackageJson();
   updateTsconfig();
 };
 
-// run pre-test subscripts
+// run post-test subscripts
 runPostTest();

--- a/post-test.js
+++ b/post-test.js
@@ -19,7 +19,7 @@ const updateTsconfig = async () => {
 // combine post-test subscripts
 const runPostTest = async () => {
   await updatePackageJson();
-  updateTsconfig();
+  await updateTsconfig();
 };
 
 // run post-test subscripts

--- a/pre-test.js
+++ b/pre-test.js
@@ -19,7 +19,7 @@ const updateTsconfig = async () => {
 // combine pre-test subscripts
 const runPreTest = async () => {
   await updatePackageJson();
-  updateTsconfig();
+  await updateTsconfig();
 };
 
 // run pre-test subscripts

--- a/src/credential-status-manager-base.ts
+++ b/src/credential-status-manager-base.ts
@@ -34,8 +34,8 @@ export const CREDENTIAL_STATUS_SNAPSHOT_FILE = 'snapshot.json';
 
 // Credential status manager source control service
 export enum CredentialStatusManagerService {
-  Github = 'github',
-  Gitlab = 'gitlab'
+  GitHub = 'github',
+  GitLab = 'gitlab'
 }
 
 // States of credential resulting from caller actions and tracked in status log

--- a/src/credential-status-manager-base.ts
+++ b/src/credential-status-manager-base.ts
@@ -406,7 +406,7 @@ export abstract class BaseCredentialStatusManager {
     // unable to find credential with given ID
     if (!logEntry) {
       throw new NotFoundError({
-        message: `Unable to find credential with given ID "${credentialId}".`
+        message: `Unable to find credential with ID "${credentialId}".`
       });
     }
 
@@ -538,7 +538,7 @@ export abstract class BaseCredentialStatusManager {
     // unable to find credential with given ID
     if (!logEntry) {
       throw new NotFoundError({
-        message: `Unable to find credential with given ID "${credentialId}".`
+        message: `Unable to find credential with ID "${credentialId}".`
       });
     }
 

--- a/src/credential-status-manager-base.ts
+++ b/src/credential-status-manager-base.ts
@@ -535,7 +535,7 @@ export abstract class BaseCredentialStatusManager {
   async deployCredentialStatusWebsite(): Promise<void> {};
 
   // checks if caller has authority to update status based on status repo access token
-  abstract hasStatusAuthority(repoAccessToken: string): Promise<boolean>;
+  abstract hasStatusAuthority(repoAccessToken: string, metaRepoAccessToken?: string): Promise<boolean>;
 
   // checks if status repos exist
   abstract statusReposExist(): Promise<boolean>;

--- a/src/credential-status-manager-base.ts
+++ b/src/credential-status-manager-base.ts
@@ -206,7 +206,7 @@ export abstract class BaseCredentialStatusManager {
         id: credentialStatusId,
         type: CREDENTIAL_STATUS_TYPE,
         statusPurpose,
-        statusListIndex: credentialStatusIndex,
+        statusListIndex: credentialStatusIndex.toString(),
         statusListCredential: statusCredentialUrl
       };
 
@@ -243,7 +243,7 @@ export abstract class BaseCredentialStatusManager {
       id: credentialStatusId,
       type: CREDENTIAL_STATUS_TYPE,
       statusPurpose,
-      statusListIndex: credentialStatusIndex,
+      statusListIndex: credentialStatusIndex.toString(),
       statusListCredential: statusCredentialUrl
     };
 
@@ -331,7 +331,7 @@ export abstract class BaseCredentialStatusManager {
     // extract relevant data from credential status
     const {
       statusListCredential: statusCredentialUrl,
-      statusListIndex: credentialStatusIndex
+      statusListIndex
     } = credentialWithStatus.credentialStatus;
 
     // retrieve status credential ID from status credential URL
@@ -346,7 +346,7 @@ export abstract class BaseCredentialStatusManager {
       credentialState: CredentialState.Active,
       verificationMethod,
       statusCredentialId,
-      credentialStatusIndex
+      credentialStatusIndex: parseInt(statusListIndex)
     };
     eventLog.push(statusLogEntry);
 

--- a/src/credential-status-manager-base.ts
+++ b/src/credential-status-manager-base.ts
@@ -182,6 +182,11 @@ export abstract class BaseCredentialStatusManager {
       credential.id = uuid();
     }
 
+    // ensure that credential contains the proper status credential context
+    if (!credential['@context'].includes(CONTEXT_URL_V1)) {
+      credential['@context'].push(CONTEXT_URL_V1);
+    }
+
     // retrieve status config data
     let {
       latestStatusCredentialId,
@@ -217,8 +222,7 @@ export abstract class BaseCredentialStatusManager {
       return {
         credential: {
           ...credential,
-          credentialStatus,
-          '@context': ensureStatusCredentialContext(credential['@context'])
+          credentialStatus
         },
         newStatusCredential: false,
         latestStatusCredentialId,
@@ -254,8 +258,7 @@ export abstract class BaseCredentialStatusManager {
     return {
       credential: {
         ...credential,
-        credentialStatus,
-        '@context': ensureStatusCredentialContext(credential['@context'])
+        credentialStatus
       },
       newStatusCredential,
       latestStatusCredentialId,
@@ -746,13 +749,6 @@ export abstract class BaseCredentialStatusManager {
     }
   }
 }
-
-// ensures that the proper status credential context is included
-const ensureStatusCredentialContext = (currentContext: any[]): void => {
-  if (!currentContext.includes(CONTEXT_URL_V1)) {
-    currentContext.push(CONTEXT_URL_V1);
-  }
-};
 
 // composes StatusList2021Credential
 export async function composeStatusCredential({

--- a/src/credential-status-manager-base.ts
+++ b/src/credential-status-manager-base.ts
@@ -369,14 +369,13 @@ export abstract class BaseCredentialStatusManager {
       const result = await this.allocateStatusUnsafe(credential);
       return result;
     } catch(error) {
-      await this.cleanupSnapshotData();
-      release();
       if (!(error instanceof StatusRepoInconsistencyError)) {
         return this.allocateStatus(credential);
       } else {
         throw error;
       }
     } finally {
+      await this.cleanupSnapshotData();
       release();
     }
   }
@@ -498,8 +497,6 @@ export abstract class BaseCredentialStatusManager {
       const result = await this.updateStatusUnsafe({ credentialId, credentialStatus });
       return result;
     } catch(error) {
-      await this.cleanupSnapshotData();
-      release();
       if (!(error instanceof StatusRepoInconsistencyError)) {
         return this.updateStatus({
           credentialId,
@@ -509,6 +506,7 @@ export abstract class BaseCredentialStatusManager {
         throw error;
       }
     } finally {
+      await this.cleanupSnapshotData();
       release();
     }
   }

--- a/src/credential-status-manager-base.ts
+++ b/src/credential-status-manager-base.ts
@@ -9,6 +9,7 @@ import { v4 as uuid } from 'uuid';
 import {
   BadRequestError,
   InconsistentRepositoryError,
+  NotFoundError,
   SnapshotExistsError
 } from './errors.js';
 import {
@@ -404,7 +405,7 @@ export abstract class BaseCredentialStatusManager {
 
     // unable to find credential with given ID
     if (!logEntry) {
-      throw new BadRequestError({
+      throw new NotFoundError({
         message: `Unable to find credential with given ID "${credentialId}".`
       });
     }
@@ -536,7 +537,7 @@ export abstract class BaseCredentialStatusManager {
 
     // unable to find credential with given ID
     if (!logEntry) {
-      throw new BadRequestError({
+      throw new NotFoundError({
         message: `Unable to find credential with given ID "${credentialId}".`
       });
     }

--- a/src/credential-status-manager-base.ts
+++ b/src/credential-status-manager-base.ts
@@ -459,7 +459,7 @@ export abstract class BaseCredentialStatusManager {
         throw new BadRequestError({
           message:
             '"credentialStatus" must be one of the following values: ' +
-            `${Object.values(CredentialState).join(', ')}.`
+            `${Object.values(CredentialState).map(s => `"${s}"`).join(', ')}.`
         });
     }
     const statusCredentialUrlBase = this.getStatusCredentialUrlBase();

--- a/src/credential-status-manager-base.ts
+++ b/src/credential-status-manager-base.ts
@@ -624,7 +624,10 @@ export abstract class BaseCredentialStatusManager {
       const credentialIdsUnique = credentialIds.filter((value, index, array) => {
         return array.indexOf(value) === index;
       });
-      const hasProperLogEntries = credentialIdsUnique.length === latestCredentialsIssuedCounter;
+      const hasProperLogEntries = credentialIdsUnique.length ===
+                                  (statusCredentialIds.length - 1) *
+                                  CREDENTIAL_STATUS_LIST_SIZE +
+                                  latestCredentialsIssuedCounter;
 
       // ensure that all checks pass
       return hasProperLogDataType && hasProperLogEntries;
@@ -715,7 +718,7 @@ export abstract class BaseCredentialStatusManager {
       ...configData
     } = await this.readSnapshotData();
 
-    // this is necssary for cases in which a transactional operation such as
+    // this is necessary for cases in which a transactional operation such as
     // allocateStatus results in a new status credential file but must be
     // reversed because of an intermittent interruption
     await this.deleteStatusData();
@@ -733,6 +736,7 @@ export abstract class BaseCredentialStatusManager {
     await this.deleteSnapshotData();
   }
 
+  // clean up snapshot data
   async cleanupSnapshotData(): Promise<void> {
     const reposProperlyConfigured = await this.statusReposProperlyConfigured();
     const snapshotExists = await this.snapshotDataExists();

--- a/src/credential-status-manager-base.ts
+++ b/src/credential-status-manager-base.ts
@@ -458,7 +458,7 @@ export abstract class BaseCredentialStatusManager {
         throw new BadRequestError({
           message:
             '"credentialStatus" must be one of the following values: ' +
-            `${Object.values(CredentialState).map(v => `'${v}'`).join(', ')}.`
+            `${Object.values(CredentialState).join(', ')}.`
         });
     }
     const statusCredentialUrlBase = this.getStatusCredentialUrlBase();

--- a/src/credential-status-manager-base.ts
+++ b/src/credential-status-manager-base.ts
@@ -218,7 +218,7 @@ export abstract class BaseCredentialStatusManager {
         credential: {
           ...credential,
           credentialStatus,
-          '@context': [...credential['@context'], CONTEXT_URL_V1]
+          '@context': ensureStatusCredentialContext(credential['@context'])
         },
         newStatusCredential: false,
         latestStatusCredentialId,
@@ -232,8 +232,8 @@ export abstract class BaseCredentialStatusManager {
     let newStatusCredential = false;
     if (latestCredentialsIssuedCounter >= CREDENTIAL_STATUS_LIST_SIZE) {
       newStatusCredential = true;
-      latestStatusCredentialId = this.generateStatusCredentialId();
       latestCredentialsIssuedCounter = 0;
+      latestStatusCredentialId = this.generateStatusCredentialId();
       statusCredentialIds.push(latestStatusCredentialId);
     }
     latestCredentialsIssuedCounter++;
@@ -255,7 +255,7 @@ export abstract class BaseCredentialStatusManager {
       credential: {
         ...credential,
         credentialStatus,
-        '@context': [...credential['@context'], CONTEXT_URL_V1]
+        '@context': ensureStatusCredentialContext(credential['@context'])
       },
       newStatusCredential,
       latestStatusCredentialId,
@@ -746,6 +746,13 @@ export abstract class BaseCredentialStatusManager {
     }
   }
 }
+
+// ensures that the proper status credential context is included
+const ensureStatusCredentialContext = (currentContext: any[]): void => {
+  if (!currentContext.includes(CONTEXT_URL_V1)) {
+    currentContext.push(CONTEXT_URL_V1);
+  }
+};
 
 // composes StatusList2021Credential
 export async function composeStatusCredential({

--- a/src/credential-status-manager-base.ts
+++ b/src/credential-status-manager-base.ts
@@ -525,7 +525,7 @@ export abstract class BaseCredentialStatusManager {
     }
   }
 
-  // checks status of credential
+  // checks status of credential with given ID
   async checkStatus(credentialId: string): Promise<CredentialStatusLogEntry> {
     // find latest relevant log entry for credential with given ID
     const { eventLog } = await this.readConfigData();
@@ -736,7 +736,7 @@ export abstract class BaseCredentialStatusManager {
     await this.deleteSnapshotData();
   }
 
-  // clean up snapshot data
+  // cleans up snapshot data
   async cleanupSnapshotData(): Promise<void> {
     const reposProperlyConfigured = await this.statusReposProperlyConfigured();
     const snapshotExists = await this.snapshotDataExists();

--- a/src/credential-status-manager-github.ts
+++ b/src/credential-status-manager-github.ts
@@ -123,10 +123,9 @@ export class GithubCredentialStatusManager extends BaseCredentialStatusManager {
   // checks if caller has authority to update status based on status repo access token
   async hasStatusAuthority(repoAccessToken: string, metaRepoAccessToken?: string): Promise<boolean> {
     this.resetClientAuthorization(repoAccessToken, metaRepoAccessToken);
+
     let hasRepoAccess: boolean;
     let hasRepoScope: boolean;
-    let hasMetaRepoAccess: boolean;
-    let hasMetaRepoScope: boolean;
     try {
       const repoResponse = await this.repoClient.repos.get({
         owner: this.ownerAccountName,
@@ -141,6 +140,9 @@ export class GithubCredentialStatusManager extends BaseCredentialStatusManager {
       hasRepoAccess = false;
       hasRepoScope = false;
     }
+
+    let hasMetaRepoAccess: boolean;
+    let hasMetaRepoScope: boolean;
     try {
       const metaRepoResponse = await this.metaRepoClient.repos.get({
         owner: this.ownerAccountName,
@@ -155,6 +157,7 @@ export class GithubCredentialStatusManager extends BaseCredentialStatusManager {
       hasMetaRepoAccess = false;
       hasMetaRepoScope = false;
     }
+
     return hasRepoAccess && hasRepoScope && hasMetaRepoAccess && hasMetaRepoScope;
   }
 

--- a/src/credential-status-manager-github.ts
+++ b/src/credential-status-manager-github.ts
@@ -88,7 +88,7 @@ export class GitHubCredentialStatusManager extends BaseCredentialStatusManager {
         message:
           'You have neglected to set the following required options for the ' +
           'GitHub credential status manager: ' +
-          `${missingOptions.join(', ')}.`
+          `${missingOptions.map(o => `"${o}"`).join(', ')}.`
       });
     }
 

--- a/src/credential-status-manager-github.ts
+++ b/src/credential-status-manager-github.ts
@@ -88,7 +88,7 @@ export class GitHubCredentialStatusManager extends BaseCredentialStatusManager {
         message:
           'You have neglected to set the following required options for the ' +
           'GitHub credential status manager: ' +
-          `${missingOptions.map(o => `'${o}'`).join(', ')}.`
+          `${missingOptions.join(', ')}.`
       });
     }
 

--- a/src/credential-status-manager-github.ts
+++ b/src/credential-status-manager-github.ts
@@ -13,6 +13,7 @@ import {
   CredentialStatusConfigData,
   CredentialStatusSnapshotData
 } from './credential-status-manager-base.js';
+import { BadRequestError } from './errors.js';
 import {
   DidMethod,
   decodeSystemData,
@@ -83,18 +84,20 @@ export class GithubCredentialStatusManager extends BaseCredentialStatusManager {
     );
 
     if (!isProperlyConfigured) {
-      throw new Error(
-        'You have neglected to set the following required options for the ' +
-        'GitHub credential status manager: ' +
-        `${missingOptions.map(o => `'${o}'`).join(', ')}.`
-      );
+      throw new BadRequestError({
+        message:
+          'You have neglected to set the following required options for the ' +
+          'GitHub credential status manager: ' +
+          `${missingOptions.map(o => `'${o}'`).join(', ')}.`
+      });
     }
 
     if (this.didMethod === DidMethod.Web && !this.didWebUrl) {
-      throw new Error(
-        'The value of "didWebUrl" must be provided ' +
-        'when using "didMethod" of type "web".'
-      );
+      throw new BadRequestError({
+        message:
+          'The value of "didWebUrl" must be provided ' +
+          'when using "didMethod" of type "web".'
+      });
     }
   }
 
@@ -231,7 +234,9 @@ export class GithubCredentialStatusManager extends BaseCredentialStatusManager {
   // creates data in status file
   async createStatusData(data: VerifiableCredential): Promise<void> {
     if (typeof data === 'string') {
-      throw new Error('This library does not support compact JWT credentials.');
+      throw new BadRequestError({
+        message: 'This library does not support compact JWT credentials.'
+      });
     }
     const statusCredentialId = deriveStatusCredentialId(data.id as string);
     const timestamp = getDateString();
@@ -272,7 +277,9 @@ export class GithubCredentialStatusManager extends BaseCredentialStatusManager {
   // updates data in status file
   async updateStatusData(data: VerifiableCredential): Promise<void> {
     if (typeof data === 'string') {
-      throw new Error('This library does not support compact JWT credentials.');
+      throw new BadRequestError({
+        message: 'This library does not support compact JWT credentials.'
+      });
     }
     const statusCredentialId = deriveStatusCredentialId(data.id as string);
     const statusResponse = await this.readStatusResponse();

--- a/src/credential-status-manager-github.ts
+++ b/src/credential-status-manager-github.ts
@@ -22,24 +22,24 @@ import {
   getDateString
 } from './helpers.js';
 
-// Type definition for GithubCredentialStatusManager constructor method input
-export type GithubCredentialStatusManagerOptions = {
+// Type definition for GitHubCredentialStatusManager constructor method input
+export type GitHubCredentialStatusManagerOptions = {
   ownerAccountName: string;
 } & BaseCredentialStatusManagerOptions;
 
-// Minimal set of options required for configuring GithubCredentialStatusManager
+// Minimal set of options required for configuring GitHubCredentialStatusManager
 const GITHUB_MANAGER_REQUIRED_OPTIONS = [
   'ownerAccountName'
 ].concat(BASE_MANAGER_REQUIRED_OPTIONS) as
-  Array<keyof GithubCredentialStatusManagerOptions & BaseCredentialStatusManagerOptions>;
+  Array<keyof GitHubCredentialStatusManagerOptions & BaseCredentialStatusManagerOptions>;
 
 // Implementation of BaseCredentialStatusManager for GitHub
-export class GithubCredentialStatusManager extends BaseCredentialStatusManager {
+export class GitHubCredentialStatusManager extends BaseCredentialStatusManager {
   private readonly ownerAccountName: string;
   private repoClient: Octokit;
   private metaRepoClient: Octokit;
 
-  constructor(options: GithubCredentialStatusManagerOptions) {
+  constructor(options: GitHubCredentialStatusManagerOptions) {
     const {
       ownerAccountName,
       repoName,
@@ -70,12 +70,12 @@ export class GithubCredentialStatusManager extends BaseCredentialStatusManager {
   }
 
   // ensures proper configuration of GitHub status manager
-  ensureProperConfiguration(options: GithubCredentialStatusManagerOptions): void {
+  ensureProperConfiguration(options: GitHubCredentialStatusManagerOptions): void {
     const missingOptions = [] as
-      Array<keyof GithubCredentialStatusManagerOptions & BaseCredentialStatusManagerOptions>;
+      Array<keyof GitHubCredentialStatusManagerOptions & BaseCredentialStatusManagerOptions>;
 
     const isProperlyConfigured = GITHUB_MANAGER_REQUIRED_OPTIONS.every(
-      (option: keyof GithubCredentialStatusManagerOptions) => {
+      (option: keyof GitHubCredentialStatusManagerOptions) => {
         if (!options[option]) {
           missingOptions.push(option as any);
         }

--- a/src/credential-status-manager-gitlab.ts
+++ b/src/credential-status-manager-gitlab.ts
@@ -153,7 +153,7 @@ export class GitLabCredentialStatusManager extends BaseCredentialStatusManager {
         message:
           'You have neglected to set the following required options for the ' +
           'GitLab credential status manager: ' +
-          `${missingOptions.map(o => `'${o}'`).join(', ')}.`
+          `${missingOptions.join(', ')}.`
       });
     }
 

--- a/src/credential-status-manager-gitlab.ts
+++ b/src/credential-status-manager-gitlab.ts
@@ -13,6 +13,7 @@ import {
   CredentialStatusConfigData,
   CredentialStatusSnapshotData
 } from './credential-status-manager-base.js';
+import { BadRequestError } from './errors.js';
 import {
   DidMethod,
   decodeSystemData,
@@ -148,18 +149,20 @@ export class GitlabCredentialStatusManager extends BaseCredentialStatusManager {
     );
 
     if (!isProperlyConfigured) {
-      throw new Error(
-        'You have neglected to set the following required options for the ' +
-        'GitLab credential status manager: ' +
-        `${missingOptions.map(o => `'${o}'`).join(', ')}.`
-      );
+      throw new BadRequestError({
+        message:
+          'You have neglected to set the following required options for the ' +
+          'GitLab credential status manager: ' +
+          `${missingOptions.map(o => `'${o}'`).join(', ')}.`
+      });
     }
 
     if (this.didMethod === DidMethod.Web && !this.didWebUrl) {
-      throw new Error(
-        'The value of "didWebUrl" must be provided ' +
-        'when using "didMethod" of type "web".'
-      );
+      throw new BadRequestError({
+        message:
+          'The value of "didWebUrl" must be provided ' +
+          'when using "didMethod" of type "web".'
+      });
     }
   }
 
@@ -355,7 +358,9 @@ export class GitlabCredentialStatusManager extends BaseCredentialStatusManager {
   // creates data in status file
   async createStatusData(data: VerifiableCredential): Promise<void> {
     if (typeof data === 'string') {
-      throw new Error('This library does not support compact JWT credentials.');
+      throw new BadRequestError({
+        message: 'This library does not support compact JWT credentials.'
+      });
     }
     const statusCredentialId = deriveStatusCredentialId(data.id as string);
     const timestamp = getDateString();
@@ -399,7 +404,9 @@ export class GitlabCredentialStatusManager extends BaseCredentialStatusManager {
   // updates data in status file
   async updateStatusData(data: VerifiableCredential): Promise<void> {
     if (typeof data === 'string') {
-      throw new Error('This library does not support compact JWT credentials.');
+      throw new BadRequestError({
+        message: 'This library does not support compact JWT credentials.'
+      });
     }
     const statusCredentialId = deriveStatusCredentialId(data.id as string);
     const timestamp = getDateString();

--- a/src/credential-status-manager-gitlab.ts
+++ b/src/credential-status-manager-gitlab.ts
@@ -240,18 +240,21 @@ export class GitlabCredentialStatusManager extends BaseCredentialStatusManager {
   // checks if caller has authority to update status based on status repo access token
   async hasStatusAuthority(repoAccessToken: string, metaRepoAccessToken?: string): Promise<boolean> {
     this.resetClientAuthorization(repoAccessToken, metaRepoAccessToken);
+
     let hasRepoAccess = true;
-    let hasMetaRepoAccess = true;
     try {
       await this.readRepoData();
     } catch (error: any) {
       hasRepoAccess = false;
     }
+
+    let hasMetaRepoAccess = true;
     try {
       await this.readMetaRepoData();
     } catch (error: any) {
       hasMetaRepoAccess = false;
     }
+
     return hasRepoAccess && hasMetaRepoAccess;
   }
 

--- a/src/credential-status-manager-gitlab.ts
+++ b/src/credential-status-manager-gitlab.ts
@@ -65,30 +65,30 @@ const CREDENTIAL_STATUS_WEBSITE_FILE_PATHS = [
   CREDENTIAL_STATUS_WEBSITE_GEMFILE_PATH
 ];
 
-// Type definition for GitlabCredentialStatusManager constructor method input
-export type GitlabCredentialStatusManagerOptions = {
+// Type definition for GitLabCredentialStatusManager constructor method input
+export type GitLabCredentialStatusManagerOptions = {
   ownerAccountName: string;
   repoId: string;
   metaRepoId: string;
 } & BaseCredentialStatusManagerOptions;
 
-// Minimal set of options required for configuring GitlabCredentialStatusManager
+// Minimal set of options required for configuring GitLabCredentialStatusManager
 const GITLAB_MANAGER_REQUIRED_OPTIONS = [
   'ownerAccountName',
   'repoId',
   'metaRepoId'
 ].concat(BASE_MANAGER_REQUIRED_OPTIONS) as
-  Array<keyof GitlabCredentialStatusManagerOptions & BaseCredentialStatusManagerOptions>;
+  Array<keyof GitLabCredentialStatusManagerOptions & BaseCredentialStatusManagerOptions>;
 
 // Implementation of BaseCredentialStatusManager for GitLab
-export class GitlabCredentialStatusManager extends BaseCredentialStatusManager {
+export class GitLabCredentialStatusManager extends BaseCredentialStatusManager {
   private readonly ownerAccountName: string;
   private readonly repoId: string;
   private readonly metaRepoId: string;
   private repoClient: AxiosInstance;
   private metaRepoClient: AxiosInstance;
 
-  constructor(options: GitlabCredentialStatusManagerOptions) {
+  constructor(options: GitLabCredentialStatusManagerOptions) {
     const {
       ownerAccountName,
       repoName,
@@ -135,12 +135,12 @@ export class GitlabCredentialStatusManager extends BaseCredentialStatusManager {
   }
 
   // ensures proper configuration of GitLab status manager
-  ensureProperConfiguration(options: GitlabCredentialStatusManagerOptions): void {
+  ensureProperConfiguration(options: GitLabCredentialStatusManagerOptions): void {
     const missingOptions = [] as
-      Array<keyof GitlabCredentialStatusManagerOptions & BaseCredentialStatusManagerOptions>;
+      Array<keyof GitLabCredentialStatusManagerOptions & BaseCredentialStatusManagerOptions>;
 
     const isProperlyConfigured = GITLAB_MANAGER_REQUIRED_OPTIONS.every(
-      (option: keyof GitlabCredentialStatusManagerOptions) => {
+      (option: keyof GitLabCredentialStatusManagerOptions) => {
         if (!options[option]) {
           missingOptions.push(option as any);
         }

--- a/src/credential-status-manager-gitlab.ts
+++ b/src/credential-status-manager-gitlab.ts
@@ -153,7 +153,7 @@ export class GitLabCredentialStatusManager extends BaseCredentialStatusManager {
         message:
           'You have neglected to set the following required options for the ' +
           'GitLab credential status manager: ' +
-          `${missingOptions.join(', ')}.`
+          `${missingOptions.map(o => `"${o}"`).join(', ')}.`
       });
     }
 

--- a/src/credential-status-manager-index.ts
+++ b/src/credential-status-manager-index.ts
@@ -95,15 +95,16 @@ export async function createStatusManager(options: CredentialStatusManagerOption
 
   // retrieve relevant data from status repo configuration
   const hasAccess = await statusManager.hasStatusAuthority(repoAccessToken, metaRepoAccessToken);
-  const reposExist = await statusManager.statusReposExist();
-  const reposEmpty = await statusManager.statusReposEmpty();
-
   if (!hasAccess) {
     throw new Error(`One or more of the access tokens you are using for the credential status repo ("${repoName}") and the credential status metadata repo ("${metaRepoName}") are incorrect or expired.`);
   }
+
+  const reposExist = await statusManager.statusReposExist();
   if (!reposExist) {
     throw new Error(`The credential status repo ("${repoName}") and the credential status metadata repo ("${metaRepoName}") must be manually created in advance.`);
   }
+
+  const reposEmpty = await statusManager.statusReposEmpty();
   if (!reposEmpty) {
     await statusManager.cleanupSnapshotData();
   } else {

--- a/src/credential-status-manager-index.ts
+++ b/src/credential-status-manager-index.ts
@@ -88,7 +88,7 @@ export async function createStatusManager(options: CredentialStatusManagerOption
       throw new BadRequestError({
         message:
           '"service" must be one of the following values: ' +
-          `${Object.values(CredentialStatusManagerService).map(v => `'${v}'`).join(', ')}.`
+          `${Object.values(CredentialStatusManagerService).join(', ')}.`
       });
   }
 

--- a/src/credential-status-manager-index.ts
+++ b/src/credential-status-manager-index.ts
@@ -4,7 +4,6 @@
 import {
   BaseCredentialStatusManager,
   CredentialStatusConfigData,
-  CredentialStatusLogData,
   CredentialStatusManagerService,
   composeStatusCredential
 } from './credential-status-manager-base.js';
@@ -112,13 +111,10 @@ export async function createStatusManager(options: CredentialStatusManagerOption
     const listId = statusManager.generateStatusListId();
     const configData: CredentialStatusConfigData = {
       credentialsIssued: 0,
-      latestList: listId
+      latestList: listId,
+      log: []
     };
     await statusManager.createConfigData(configData);
-
-    // create and persist status log
-    const logData: CredentialStatusLogData = [];
-    await statusManager.createLogData(logData);
 
     // create status credential
     const statusCredentialId = `${credentialStatusUrl}/${listId}`;

--- a/src/credential-status-manager-index.ts
+++ b/src/credential-status-manager-index.ts
@@ -94,9 +94,13 @@ export async function createStatusManager(options: CredentialStatusManagerOption
   });
 
   // retrieve relevant data from status repo configuration
+  const hasAccess = await statusManager.hasStatusAuthority(repoAccessToken, metaRepoAccessToken);
   const reposExist = await statusManager.statusReposExist();
   const reposEmpty = await statusManager.statusReposEmpty();
 
+  if (!hasAccess) {
+    throw new Error(`One or more of the access tokens you are using for the credential status repo ("${repoName}") and the credential status metadata repo ("${metaRepoName}") are incorrect or expired.`);
+  }
   if (!reposExist) {
     throw new Error(`The credential status repo ("${repoName}") and the credential status metadata repo ("${metaRepoName}") must be manually created in advance.`);
   }

--- a/src/credential-status-manager-index.ts
+++ b/src/credential-status-manager-index.ts
@@ -88,7 +88,7 @@ export async function createStatusManager(options: CredentialStatusManagerOption
       throw new BadRequestError({
         message:
           '"service" must be one of the following values: ' +
-          `${Object.values(CredentialStatusManagerService).join(', ')}.`
+          `${Object.values(CredentialStatusManagerService).map(s => `"${s}"`).join(', ')}.`
       });
   }
 

--- a/src/credential-status-manager-index.ts
+++ b/src/credential-status-manager-index.ts
@@ -8,12 +8,12 @@ import {
   composeStatusCredential
 } from './credential-status-manager-base.js';
 import {
-  GithubCredentialStatusManager,
-  GithubCredentialStatusManagerOptions
+  GitHubCredentialStatusManager,
+  GitHubCredentialStatusManagerOptions
 } from './credential-status-manager-github.js';
 import {
-  GitlabCredentialStatusManager,
-  GitlabCredentialStatusManagerOptions
+  GitLabCredentialStatusManager,
+  GitLabCredentialStatusManagerOptions
 } from './credential-status-manager-gitlab.js';
 import {
   BadRequestError,
@@ -29,7 +29,7 @@ interface CredentialStatusManagerBaseOptions {
 
 // Type definition for createStatusManager function input
 type CredentialStatusManagerOptions = CredentialStatusManagerBaseOptions &
-  (GithubCredentialStatusManagerOptions | GitlabCredentialStatusManagerOptions);
+  (GitHubCredentialStatusManagerOptions | GitLabCredentialStatusManagerOptions);
 
 // creates credential status manager
 export async function createStatusManager(options: CredentialStatusManagerOptions)
@@ -49,8 +49,8 @@ export async function createStatusManager(options: CredentialStatusManagerOption
   } = options;
   let statusManager: BaseCredentialStatusManager;
   switch (service) {
-    case CredentialStatusManagerService.Github:
-      statusManager = new GithubCredentialStatusManager({
+    case CredentialStatusManagerService.GitHub:
+      statusManager = new GitHubCredentialStatusManager({
         ownerAccountName,
         repoName,
         metaRepoName,
@@ -63,12 +63,12 @@ export async function createStatusManager(options: CredentialStatusManagerOption
         signStatusCredential
       });
       break;
-    case CredentialStatusManagerService.Gitlab: {
+    case CredentialStatusManagerService.GitLab: {
       const {
         repoId,
         metaRepoId
-      } = options as GitlabCredentialStatusManagerOptions;
-      statusManager = new GitlabCredentialStatusManager({
+      } = options as GitLabCredentialStatusManagerOptions;
+      statusManager = new GitLabCredentialStatusManager({
         ownerAccountName,
         repoName,
         repoId,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,25 +1,103 @@
-import { BaseCredentialStatusManager } from "./credential-status-manager-base";
+import { BaseCredentialStatusManager } from './credential-status-manager-base.js';
 
-interface StatusRepoInconsistencyErrorOptions {
+interface BaseErrorOptions {
+  statusManager?: BaseCredentialStatusManager;
+  message: string;
+}
+
+interface ChildErrorOptions {
+  statusManager?: BaseCredentialStatusManager;
+  message?: string;
+  defaultMessage: string;
+  label: string;
+}
+
+interface CustomErrorOptions {
   statusManager?: BaseCredentialStatusManager;
   message?: string;
 }
-export class StatusRepoInconsistencyError extends Error {
-  constructor(options?: StatusRepoInconsistencyErrorOptions) {
-    let statusManager, message;
-    if (!options) {
-      statusManager = undefined;
-      message = undefined;
-    } else {
-      ({ statusManager, message } = options);
-    }
-    const repoName = statusManager?.getRepoName() ?? "repoName";
-    const metaRepoName = statusManager?.getMetaRepoName() ?? "metaRepoName";
+
+class BaseError extends Error {
+  public statusManager: BaseCredentialStatusManager | undefined;
+  public message: string;
+
+  constructor(options: BaseErrorOptions) {
+    const { statusManager, message } = options;
+    super(message);
+    this.statusManager = statusManager;
+    this.message = message;
+  }
+}
+
+class ChildError extends BaseError {
+  constructor(options: ChildErrorOptions) {
+    const { statusManager, defaultMessage, label } = options;
+    const message = `[${label}] ${options?.message ?? defaultMessage}`;
+    super({ statusManager, message });
+  }
+}
+
+export class BadRequestError extends ChildError {
+  constructor(options?: CustomErrorOptions) {
+    const { statusManager, message } = options ?? {};
+    const defaultMessage = 'That is an invalid request.';
+    const label = 'BadRequestError';
+    super({ statusManager, message, defaultMessage, label });
+  }
+}
+
+export class InvalidDidSeedError extends ChildError {
+  constructor(options?: CustomErrorOptions) {
+    const { statusManager, message } = options ?? {};
+    const defaultMessage = '"didSeed" must be a multibase-encoded value with at least 32 bytes.';
+    const label = 'InvalidDidSeedError';
+    super({ statusManager, message, defaultMessage, label });
+  }
+}
+
+export class InvalidTokenError extends ChildError {
+  constructor(options?: CustomErrorOptions) {
+    const { statusManager, message } = options ?? {};
+    const repoName = statusManager?.getRepoName() ?? 'repoName';
+    const metaRepoName = statusManager?.getMetaRepoName() ?? 'metaRepoName';
+    const defaultMessage = `One or more of the access tokens you are using for the ` +
+      `credential status repo ("${repoName}") and the ` +
+      `credential status metadata repo ("${metaRepoName}") are incorrect or expired.`;
+    const label = 'InvalidTokenError';
+    super({ statusManager, message, defaultMessage, label });
+  }
+}
+
+export class MissingRepositoryError extends ChildError {
+  constructor(options?: CustomErrorOptions) {
+    const { statusManager, message } = options ?? {};
+    const repoName = statusManager?.getRepoName() ?? 'repoName';
+    const metaRepoName = statusManager?.getMetaRepoName() ?? 'metaRepoName';
+    const defaultMessage = `The credential status repo ("${repoName}") and the ` +
+      `credential status metadata repo ("${metaRepoName}") must be manually created in advance.`
+    const label = 'MissingRepositoryError';
+    super({ statusManager, message, defaultMessage, label });
+  }
+}
+
+export class SnapshotExistsError extends ChildError {
+  constructor(options?: CustomErrorOptions) {
+    const { statusManager, message } = options ?? {};
+    const defaultMessage = 'Snapshot data already exists.';
+    const label = 'SnapshotExistsError';
+    super({ statusManager, message, defaultMessage, label });
+  }
+}
+
+export class InconsistentRepositoryError extends ChildError {
+  constructor(options?: CustomErrorOptions) {
+    const { statusManager, message } = options ?? {};
+    const repoName = statusManager?.getRepoName() ?? 'repoName';
+    const metaRepoName = statusManager?.getMetaRepoName() ?? 'metaRepoName';
     const defaultMessage = `Inconsistencies in the status repos may need to be manually resolved. ` +
       `If this is your first operation with this library (e.g., "createStatusManager"), please make sure that the ` +
       `credential status repo ("${repoName}") and the credential status metadata repo ("${metaRepoName}") are empty.`;
-    super(`StatusRepoInconsistencyError: ${message ?? defaultMessage}`);
-    // Set the prototype explicitly.
-    Object.setPrototypeOf(this, StatusRepoInconsistencyError.prototype);
+    const label = 'InconsistentRepositoryError';
+    super({ statusManager, message, defaultMessage, label });
   }
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -46,6 +46,15 @@ export class BadRequestError extends ChildError {
   }
 }
 
+export class NotFoundError extends ChildError {
+  constructor(options?: CustomErrorOptions) {
+    const { statusManager, message } = options ?? {};
+    const defaultMessage = 'Resource not found.';
+    const label = 'NotFoundError';
+    super({ statusManager, message, defaultMessage, label });
+  }
+}
+
 export class InvalidDidSeedError extends ChildError {
   constructor(options?: CustomErrorOptions) {
     const { statusManager, message } = options ?? {};

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,25 @@
+import { BaseCredentialStatusManager } from "./credential-status-manager-base";
+
+interface StatusRepoInconsistencyErrorOptions {
+  statusManager?: BaseCredentialStatusManager;
+  message?: string;
+}
+export class StatusRepoInconsistencyError extends Error {
+  constructor(options?: StatusRepoInconsistencyErrorOptions) {
+    let statusManager, message;
+    if (!options) {
+      statusManager = undefined;
+      message = undefined;
+    } else {
+      ({ statusManager, message } = options);
+    }
+    const repoName = statusManager?.getRepoName() ?? "repoName";
+    const metaRepoName = statusManager?.getMetaRepoName() ?? "metaRepoName";
+    const defaultMessage = `Inconsistencies in the status repos may need to be manually resolved. ` +
+      `If this is your first operation with this library (e.g., "createStatusManager"), please make sure that the ` +
+      `credential status repo ("${repoName}") and the credential status metadata repo ("${metaRepoName}") are empty.`;
+    super(`StatusRepoInconsistencyError: ${message ?? defaultMessage}`);
+    // Set the prototype explicitly.
+    Object.setPrototypeOf(this, StatusRepoInconsistencyError.prototype);
+  }
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,112 +1,91 @@
 import { BaseCredentialStatusManager } from './credential-status-manager-base.js';
 
-interface BaseErrorOptions {
-  statusManager?: BaseCredentialStatusManager;
-  message: string;
-}
-
-interface ChildErrorOptions {
+interface CustomErrorOptionalOptions {
   statusManager?: BaseCredentialStatusManager;
   message?: string;
+}
+
+interface CustomErrorRequiredOptions {
   defaultMessage: string;
-  label: string;
+  code: number;
 }
 
-interface CustomErrorOptions {
-  statusManager?: BaseCredentialStatusManager;
-  message?: string;
-}
+type CustomErrorOptions = CustomErrorOptionalOptions & CustomErrorRequiredOptions;
 
-class BaseError extends Error {
-  public statusManager: BaseCredentialStatusManager | undefined;
-  public message: string;
+class CustomError extends Error {
+  public code: number;
 
-  constructor(options: BaseErrorOptions) {
-    const { statusManager, message } = options;
+  constructor(options: CustomErrorOptions) {
+    const { defaultMessage, code } = options;
+    const message = `${options?.message ?? defaultMessage}`;
     super(message);
-    this.statusManager = statusManager;
-    this.message = message;
+    this.code = code;
   }
 }
 
-class ChildError extends BaseError {
-  constructor(options: ChildErrorOptions) {
-    const { statusManager, defaultMessage, label } = options;
-    const message = `[${label}] ${options?.message ?? defaultMessage}`;
-    super({ statusManager, message });
-  }
-}
-
-export class BadRequestError extends ChildError {
-  constructor(options?: CustomErrorOptions) {
-    const { statusManager, message } = options ?? {};
+export class BadRequestError extends CustomError {
+  constructor(options?: CustomErrorOptionalOptions) {
+    const { message } = options ?? {};
     const defaultMessage = 'That is an invalid request.';
-    const label = 'BadRequestError';
-    super({ statusManager, message, defaultMessage, label });
+    super({ message, defaultMessage, code: 400 });
   }
 }
 
-export class NotFoundError extends ChildError {
-  constructor(options?: CustomErrorOptions) {
-    const { statusManager, message } = options ?? {};
+export class NotFoundError extends CustomError {
+  constructor(options?: CustomErrorOptionalOptions) {
+    const { message } = options ?? {};
     const defaultMessage = 'Resource not found.';
-    const label = 'NotFoundError';
-    super({ statusManager, message, defaultMessage, label });
+    super({ message, defaultMessage, code: 404 });
   }
 }
 
-export class InvalidDidSeedError extends ChildError {
-  constructor(options?: CustomErrorOptions) {
-    const { statusManager, message } = options ?? {};
+export class InvalidDidSeedError extends CustomError {
+  constructor(options?: CustomErrorOptionalOptions) {
+    const { message } = options ?? {};
     const defaultMessage = '"didSeed" must be a multibase-encoded value with at least 32 bytes.';
-    const label = 'InvalidDidSeedError';
-    super({ statusManager, message, defaultMessage, label });
+    super({ message, defaultMessage, code: 400 });
   }
 }
 
-export class InvalidTokenError extends ChildError {
-  constructor(options?: CustomErrorOptions) {
+export class InvalidTokenError extends CustomError {
+  constructor(options?: CustomErrorOptionalOptions) {
     const { statusManager, message } = options ?? {};
     const repoName = statusManager?.getRepoName() ?? 'repoName';
     const metaRepoName = statusManager?.getMetaRepoName() ?? 'metaRepoName';
     const defaultMessage = `One or more of the access tokens you are using for the ` +
       `credential status repo ("${repoName}") and the ` +
       `credential status metadata repo ("${metaRepoName}") are incorrect or expired.`;
-    const label = 'InvalidTokenError';
-    super({ statusManager, message, defaultMessage, label });
+    super({ message, defaultMessage, code: 401 });
   }
 }
 
-export class MissingRepositoryError extends ChildError {
-  constructor(options?: CustomErrorOptions) {
+export class MissingRepositoryError extends CustomError {
+  constructor(options?: CustomErrorOptionalOptions) {
     const { statusManager, message } = options ?? {};
     const repoName = statusManager?.getRepoName() ?? 'repoName';
     const metaRepoName = statusManager?.getMetaRepoName() ?? 'metaRepoName';
     const defaultMessage = `The credential status repo ("${repoName}") and the ` +
       `credential status metadata repo ("${metaRepoName}") must be manually created in advance.`
-    const label = 'MissingRepositoryError';
-    super({ statusManager, message, defaultMessage, label });
+    super({ message, defaultMessage, code: 400 });
   }
 }
 
-export class SnapshotExistsError extends ChildError {
-  constructor(options?: CustomErrorOptions) {
-    const { statusManager, message } = options ?? {};
+export class SnapshotExistsError extends CustomError {
+  constructor(options?: CustomErrorOptionalOptions) {
+    const { message } = options ?? {};
     const defaultMessage = 'Snapshot data already exists.';
-    const label = 'SnapshotExistsError';
-    super({ statusManager, message, defaultMessage, label });
+    super({ message, defaultMessage, code: 400 });
   }
 }
 
-export class InconsistentRepositoryError extends ChildError {
-  constructor(options?: CustomErrorOptions) {
+export class InconsistentRepositoryError extends CustomError {
+  constructor(options?: CustomErrorOptionalOptions) {
     const { statusManager, message } = options ?? {};
     const repoName = statusManager?.getRepoName() ?? 'repoName';
     const metaRepoName = statusManager?.getMetaRepoName() ?? 'metaRepoName';
     const defaultMessage = `Inconsistencies in the status repos may need to be manually resolved. ` +
       `If this is your first operation with this library (e.g., "createStatusManager"), please make sure that the ` +
       `credential status repo ("${repoName}") and the credential status metadata repo ("${metaRepoName}") are empty.`;
-    const label = 'InconsistentRepositoryError';
-    super({ statusManager, message, defaultMessage, label });
+    super({ message, defaultMessage, code: 400 });
   }
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -105,7 +105,7 @@ export async function getSigningMaterial({
       throw new BadRequestError({
         message:
           '"didMethod" must be one of the following values: ' +
-          `${Object.values(DidMethod).join(', ')}.`
+          `${Object.values(DidMethod).map(m => `"${m}"`).join(', ')}.`
       });
   }
   const issuerDid = didDocument.id;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -153,6 +153,11 @@ function extractId(objectOrString: any): string {
   return objectOrString.id;
 }
 
+// extracts abbreviated ID from status list ID
+export const getAbbreviatedStatusListId = (statusListId: string): string => {
+  return statusListId.split('/').slice(-1).pop() as string;
+};
+
 // retrieves current timestamp
 export function getDateString(): string {
   return (new Date()).toISOString();

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -153,9 +153,9 @@ function extractId(objectOrString: any): string {
   return objectOrString.id;
 }
 
-// extracts abbreviated ID from status list ID
-export const getAbbreviatedStatusListId = (statusListId: string): string => {
-  return statusListId.split('/').slice(-1).pop() as string;
+// derives abbreviated ID from status credential URL
+export const deriveStatusCredentialId = (statusCredentialUrl: string): string => {
+  return statusCredentialUrl.split('/').slice(-1).pop() as string;
 };
 
 // retrieves current timestamp

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -156,11 +156,11 @@ function extractId(objectOrString: any): string {
 }
 
 // derives abbreviated ID from status credential URL
-export const deriveStatusCredentialId = (statusCredentialUrl: string): string => {
+export function deriveStatusCredentialId(statusCredentialUrl: string): string {
   return statusCredentialUrl.split('/').slice(-1).pop() as string;
-};
+}
 
 // retrieves current timestamp
 export function getDateString(): string {
   return (new Date()).toISOString();
-};
+}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -105,7 +105,7 @@ export async function getSigningMaterial({
       throw new BadRequestError({
         message:
           '"didMethod" must be one of the following values: ' +
-          `${Object.values(DidMethod).map(v => `'${v}'`).join(', ')}.`
+          `${Object.values(DidMethod).join(', ')}.`
       });
   }
   const issuerDid = didDocument.id;

--- a/test/credential-status-manager-github.spec.ts
+++ b/test/credential-status-manager-github.spec.ts
@@ -14,7 +14,7 @@ import {
   CredentialStatusManagerService,
   CredentialStatusSnapshotData
 } from '../src/credential-status-manager-base.js';
-import * as GithubStatus from '../src/credential-status-manager-github.js';
+import * as GitHubStatus from '../src/credential-status-manager-github.js';
 import {
   checkLocalCredentialStatus,
   checkRemoteCredentialStatus,
@@ -35,12 +35,12 @@ import {
 
 const sandbox = createSandbox();
 
-class MockGithubCredentialStatusManager extends GithubStatus.GithubCredentialStatusManager {
+class MockGitHubCredentialStatusManager extends GitHubStatus.GitHubCredentialStatusManager {
   private statusCredential: VerifiableCredential;
   private config: CredentialStatusConfigData;
   private snapshot: CredentialStatusSnapshotData;
 
-  constructor(options: GithubStatus.GithubCredentialStatusManagerOptions) {
+  constructor(options: GitHubStatus.GitHubCredentialStatusManagerOptions) {
     const {
       ownerAccountName,
       repoName,
@@ -156,9 +156,9 @@ class MockGithubCredentialStatusManager extends GithubStatus.GithubCredentialSta
 
 describe('GitHub Credential Status Manager', () => {
   const service = 'github' as CredentialStatusManagerService;
-  let statusManager: GithubStatus.GithubCredentialStatusManager;
+  let statusManager: GitHubStatus.GitHubCredentialStatusManager;
   sandbox.stub(OctokitClient.Octokit.prototype, 'constructor').returns(null);
-  sandbox.stub(GithubStatus, 'GithubCredentialStatusManager').value(MockGithubCredentialStatusManager);
+  sandbox.stub(GitHubStatus, 'GitHubCredentialStatusManager').value(MockGitHubCredentialStatusManager);
 
   beforeEach(async () => {
     statusManager = await createStatusManager({
@@ -170,12 +170,12 @@ describe('GitHub Credential Status Manager', () => {
       metaRepoAccessToken,
       didMethod,
       didSeed
-    }) as GithubStatus.GithubCredentialStatusManager;
+    }) as GitHubStatus.GitHubCredentialStatusManager;
   });
 
   it('tests output of createStatusManager', async () => {
     expect(statusManager).to.be.instanceof(BaseCredentialStatusManager);
-    expect(statusManager).to.be.instanceof(GithubStatus.GithubCredentialStatusManager);
+    expect(statusManager).to.be.instanceof(GitHubStatus.GitHubCredentialStatusManager);
   });
 
   it('tests allocateStatus', async () => {

--- a/test/credential-status-manager-github.spec.ts
+++ b/test/credential-status-manager-github.spec.ts
@@ -11,8 +11,6 @@ import {
   BaseCredentialStatusManager,
   CredentialState,
   CredentialStatusConfigData,
-  CredentialStatusLogData,
-  CredentialStatusLogEntry,
   CredentialStatusManagerService
 } from '../src/credential-status-manager-base.js';
 import * as GithubStatus from '../src/credential-status-manager-github.js';
@@ -38,7 +36,6 @@ const sandbox = createSandbox();
 class MockGithubCredentialStatusManager extends GithubStatus.GithubCredentialStatusManager {
   private statusCredential: VerifiableCredential;
   private statusConfig: CredentialStatusConfigData;
-  private statusLog: CredentialStatusLogEntry[];
 
   constructor(options: GithubStatus.GithubCredentialStatusManagerOptions) {
     const {
@@ -61,7 +58,6 @@ class MockGithubCredentialStatusManager extends GithubStatus.GithubCredentialSta
     });
     this.statusCredential = {} as VerifiableCredential;
     this.statusConfig = {} as CredentialStatusConfigData;
-    this.statusLog = [];
   }
 
   // generates new status list ID
@@ -101,21 +97,6 @@ class MockGithubCredentialStatusManager extends GithubStatus.GithubCredentialSta
   // updates data in config file
   async updateConfigData(data: CredentialStatusConfigData): Promise<void> {
     this.statusConfig = data;
-  }
-
-  // creates data in log file
-  async createLogData(data: CredentialStatusLogData): Promise<void> {
-    this.statusLog = data;
-  }
-
-  // retrieves data from log file
-  async readLogData(): Promise<CredentialStatusLogData> {
-    return this.statusLog;
-  }
-
-  // updates data in log file
-  async updateLogData(data: CredentialStatusLogData): Promise<void> {
-    this.statusLog = data;
   }
 
   // creates data in status file

--- a/test/credential-status-manager-github.spec.ts
+++ b/test/credential-status-manager-github.spec.ts
@@ -11,7 +11,8 @@ import {
   BaseCredentialStatusManager,
   CredentialState,
   CredentialStatusConfigData,
-  CredentialStatusManagerService
+  CredentialStatusManagerService,
+  CredentialStatusSnapshotData
 } from '../src/credential-status-manager-base.js';
 import * as GithubStatus from '../src/credential-status-manager-github.js';
 import {
@@ -35,7 +36,8 @@ const sandbox = createSandbox();
 
 class MockGithubCredentialStatusManager extends GithubStatus.GithubCredentialStatusManager {
   private statusCredential: VerifiableCredential;
-  private statusConfig: CredentialStatusConfigData;
+  private config: CredentialStatusConfigData;
+  private snapshot: CredentialStatusSnapshotData;
 
   constructor(options: GithubStatus.GithubCredentialStatusManagerOptions) {
     const {
@@ -57,7 +59,8 @@ class MockGithubCredentialStatusManager extends GithubStatus.GithubCredentialSta
       didSeed
     });
     this.statusCredential = {} as VerifiableCredential;
-    this.statusConfig = {} as CredentialStatusConfigData;
+    this.config = {} as CredentialStatusConfigData;
+    this.snapshot = {} as CredentialStatusSnapshotData;
   }
 
   // generates new status credential ID
@@ -77,6 +80,11 @@ class MockGithubCredentialStatusManager extends GithubStatus.GithubCredentialSta
   // retrieves data from status repo
   async readRepoData(): Promise<any> {
     throw new Error();
+  }
+
+  // retrieves file names from repo data
+  async readRepoFilenames(): Promise<string[]> {
+    return [statusCredentialId];
   }
 
   // retrieves data from status metadata repo
@@ -99,19 +107,49 @@ class MockGithubCredentialStatusManager extends GithubStatus.GithubCredentialSta
     this.statusCredential = data;
   }
 
+  // deletes data in status files
+  async deleteStatusData(): Promise<void> {
+    this.statusCredential = {} as VerifiableCredential;
+  }
+
   // creates data in config file
   async createConfigData(data: CredentialStatusConfigData): Promise<void> {
-    this.statusConfig = data;
+    this.config = data;
   }
 
   // retrieves data from config file
   async readConfigData(): Promise<CredentialStatusConfigData> {
-    return this.statusConfig;
+    return this.config;
   }
 
   // updates data in config file
   async updateConfigData(data: CredentialStatusConfigData): Promise<void> {
-    this.statusConfig = data;
+    this.config = data;
+  }
+
+  // deletes data in config file
+  async deleteConfigData(): Promise<void> {
+    this.config = {} as CredentialStatusConfigData;
+  }
+
+  // creates data in snapshot file
+  async createSnapshotData(data: CredentialStatusSnapshotData): Promise<void> {
+    this.snapshot = data;
+  }
+
+  // retrieves data from snapshot file
+  async readSnapshotData(): Promise<CredentialStatusSnapshotData> {
+    return this.snapshot;
+  }
+
+  // deletes data in snapshot file
+  async deleteSnapshotData(): Promise<void> {
+    this.snapshot = {} as CredentialStatusSnapshotData;
+  }
+
+  // checks if snapshot data exists
+  async snapshotDataExists(): Promise<boolean> {
+    return Object.entries(this.snapshot).length !== 0;
   }
 }
 

--- a/test/credential-status-manager-github.spec.ts
+++ b/test/credential-status-manager-github.spec.ts
@@ -18,6 +18,7 @@ import * as GithubStatus from '../src/credential-status-manager-github.js';
 import {
   checkLocalCredentialStatus,
   checkRemoteCredentialStatus,
+  checkSnapshotData,
   checkStatusCredential,
   didMethod,
   didSeed,
@@ -214,6 +215,30 @@ describe('GitHub Credential Status Manager', () => {
     // check status of credential
     const credentialStatus = await statusManager.checkStatus(credentialWithStatus.id);
     checkRemoteCredentialStatus(credentialStatus, credentialWithStatus.id, 1);
+
+    // check if status repos are properly configured
+    expect(await statusManager.statusReposProperlyConfigured()).to.be.true;
+  });
+
+  it('tests saveSnapshotData and restoreSnapshotData', async () => {
+    // allocate status for credentials
+    await statusManager.allocateStatus(unsignedCredential1) as any;
+    const credentialWithStatus2 = await statusManager.allocateStatus(unsignedCredential2) as any;
+    await statusManager.allocateStatus(unsignedCredential3) as any;
+    // update status of one credential
+    await statusManager.updateStatus({
+      credentialId: credentialWithStatus2.id,
+      credentialStatus: 'revoked' as CredentialState
+    }) as any;
+
+    // save snapshot of status repos
+    await statusManager.saveSnapshotData();
+
+    // check status credential
+    await checkSnapshotData(statusManager, 3, 1);
+
+    // save snapshot of status repos
+    await statusManager.restoreSnapshotData();
 
     // check if status repos are properly configured
     expect(await statusManager.statusReposProperlyConfigured()).to.be.true;

--- a/test/credential-status-manager-github.spec.ts
+++ b/test/credential-status-manager-github.spec.ts
@@ -25,7 +25,7 @@ import {
   ownerAccountName,
   repoAccessToken,
   repoName,
-  statusListId,
+  statusCredentialId,
   unsignedCredential1,
   unsignedCredential2,
   unsignedCredential3
@@ -60,9 +60,9 @@ class MockGithubCredentialStatusManager extends GithubStatus.GithubCredentialSta
     this.statusConfig = {} as CredentialStatusConfigData;
   }
 
-  // generates new status list ID
-  generateStatusListId(): string {
-    return statusListId;
+  // generates new status credential ID
+  generateStatusCredentialId(): string {
+    return statusCredentialId;
   }
 
   // deploys website to host credential status management resources
@@ -84,6 +84,21 @@ class MockGithubCredentialStatusManager extends GithubStatus.GithubCredentialSta
     throw new Error();
   }
 
+  // creates data in status file
+  async createStatusData(data: VerifiableCredential): Promise<void> {
+    this.statusCredential = data;
+  }
+
+  // retrieves data from status file
+  async readStatusData(statusCredentialId?: string): Promise<VerifiableCredential> {
+    return this.statusCredential;
+  }
+
+  // updates data in status file
+  async updateStatusData(data: VerifiableCredential): Promise<void> {
+    this.statusCredential = data;
+  }
+
   // creates data in config file
   async createConfigData(data: CredentialStatusConfigData): Promise<void> {
     this.statusConfig = data;
@@ -97,21 +112,6 @@ class MockGithubCredentialStatusManager extends GithubStatus.GithubCredentialSta
   // updates data in config file
   async updateConfigData(data: CredentialStatusConfigData): Promise<void> {
     this.statusConfig = data;
-  }
-
-  // creates data in status file
-  async createStatusData(data: VerifiableCredential): Promise<void> {
-    this.statusCredential = data;
-  }
-
-  // retrieves data from status file
-  async readStatusData(): Promise<VerifiableCredential> {
-    return this.statusCredential;
-  }
-
-  // updates data in status file
-  async updateStatusData(data: VerifiableCredential): Promise<void> {
-    this.statusCredential = data;
   }
 }
 

--- a/test/credential-status-manager-github.spec.ts
+++ b/test/credential-status-manager-github.spec.ts
@@ -73,7 +73,7 @@ class MockGithubCredentialStatusManager extends GithubStatus.GithubCredentialSta
   async deployCredentialStatusWebsite(): Promise<void> {}
 
   // checks if caller has authority to update status based on status repo access token
-  async hasStatusAuthority(repoAccessToken: string): Promise<boolean> { return true; }
+  async hasStatusAuthority(repoAccessToken: string, metaRepoAccessToken?: string): Promise<boolean> { return true; }
 
   // checks if status repos exist
   async statusReposExist(): Promise<boolean> { return true; }

--- a/test/credential-status-manager-gitlab.spec.ts
+++ b/test/credential-status-manager-gitlab.spec.ts
@@ -14,7 +14,7 @@ import {
   CredentialStatusManagerService,
   CredentialStatusSnapshotData
 } from '../src/credential-status-manager-base.js';
-import * as GitlabStatus from '../src/credential-status-manager-gitlab.js';
+import * as GitLabStatus from '../src/credential-status-manager-gitlab.js';
 import {
   checkLocalCredentialStatus,
   checkRemoteCredentialStatus,
@@ -37,12 +37,12 @@ import {
 
 const sandbox = createSandbox();
 
-class MockGitlabCredentialStatusManager extends GitlabStatus.GitlabCredentialStatusManager {
+class MockGitLabCredentialStatusManager extends GitLabStatus.GitLabCredentialStatusManager {
   private statusCredential: VerifiableCredential;
   private config: CredentialStatusConfigData;
   private snapshot: CredentialStatusSnapshotData;
 
-  constructor(options: GitlabStatus.GitlabCredentialStatusManagerOptions) {
+  constructor(options: GitLabStatus.GitLabCredentialStatusManagerOptions) {
     const {
       ownerAccountName,
       repoName,
@@ -162,9 +162,9 @@ class MockGitlabCredentialStatusManager extends GitlabStatus.GitlabCredentialSta
 
 describe('GitLab Credential Status Manager', () => {
   const service = 'gitlab' as CredentialStatusManagerService;
-  let statusManager: GitlabStatus.GitlabCredentialStatusManager;
+  let statusManager: GitLabStatus.GitLabCredentialStatusManager;
   sandbox.stub(AxiosClient.default, 'create').returnsThis();
-  sandbox.stub(GitlabStatus, 'GitlabCredentialStatusManager').value(MockGitlabCredentialStatusManager);
+  sandbox.stub(GitLabStatus, 'GitLabCredentialStatusManager').value(MockGitLabCredentialStatusManager);
 
   beforeEach(async () => {
     statusManager = await createStatusManager({
@@ -178,12 +178,12 @@ describe('GitLab Credential Status Manager', () => {
       metaRepoAccessToken,
       didMethod,
       didSeed
-    }) as GitlabStatus.GitlabCredentialStatusManager;
+    }) as GitLabStatus.GitLabCredentialStatusManager;
   });
 
   it('tests output of createStatusManager', async () => {
     expect(statusManager).to.be.instanceof(BaseCredentialStatusManager);
-    expect(statusManager).to.be.instanceof(GitlabStatus.GitlabCredentialStatusManager);
+    expect(statusManager).to.be.instanceof(GitLabStatus.GitLabCredentialStatusManager);
   });
 
   it('tests allocateStatus', async () => {

--- a/test/credential-status-manager-gitlab.spec.ts
+++ b/test/credential-status-manager-gitlab.spec.ts
@@ -27,7 +27,7 @@ import {
   repoAccessToken,
   repoId,
   repoName,
-  statusListId,
+  statusCredentialId,
   unsignedCredential1,
   unsignedCredential2,
   unsignedCredential3
@@ -66,9 +66,9 @@ class MockGitlabCredentialStatusManager extends GitlabStatus.GitlabCredentialSta
     this.statusConfig = {} as CredentialStatusConfigData;
   }
 
-  // generates new status list ID
-  generateStatusListId(): string {
-    return statusListId;
+  // generates new status credential ID
+  generateStatusCredentialId(): string {
+    return statusCredentialId;
   }
 
   // deploys website to host credential status management resources
@@ -90,6 +90,21 @@ class MockGitlabCredentialStatusManager extends GitlabStatus.GitlabCredentialSta
     throw new Error();
   }
 
+  // creates data in status file
+  async createStatusData(data: VerifiableCredential): Promise<void> {
+    this.statusCredential = data;
+  }
+
+  // retrieves data from status file
+  async readStatusData(statusCredentialId?: string): Promise<VerifiableCredential> {
+    return this.statusCredential;
+  }
+
+  // updates data in status file
+  async updateStatusData(data: VerifiableCredential): Promise<void> {
+    this.statusCredential = data;
+  }
+
   // creates data in config file
   async createConfigData(data: CredentialStatusConfigData): Promise<void> {
     this.statusConfig = data;
@@ -103,21 +118,6 @@ class MockGitlabCredentialStatusManager extends GitlabStatus.GitlabCredentialSta
   // updates data in config file
   async updateConfigData(data: CredentialStatusConfigData): Promise<void> {
     this.statusConfig = data;
-  }
-
-  // creates data in status file
-  async createStatusData(data: VerifiableCredential): Promise<void> {
-    this.statusCredential = data;
-  }
-
-  // retrieves data from status file
-  async readStatusData(): Promise<VerifiableCredential> {
-    return this.statusCredential;
-  }
-
-  // updates data in status file
-  async updateStatusData(data: VerifiableCredential): Promise<void> {
-    this.statusCredential = data;
   }
 }
 

--- a/test/credential-status-manager-gitlab.spec.ts
+++ b/test/credential-status-manager-gitlab.spec.ts
@@ -11,8 +11,6 @@ import {
   BaseCredentialStatusManager,
   CredentialState,
   CredentialStatusConfigData,
-  CredentialStatusLogData,
-  CredentialStatusLogEntry,
   CredentialStatusManagerService
 } from '../src/credential-status-manager-base.js';
 import * as GitlabStatus from '../src/credential-status-manager-gitlab.js';
@@ -40,7 +38,6 @@ const sandbox = createSandbox();
 class MockGitlabCredentialStatusManager extends GitlabStatus.GitlabCredentialStatusManager {
   private statusCredential: VerifiableCredential;
   private statusConfig: CredentialStatusConfigData;
-  private statusLog: CredentialStatusLogEntry[];
 
   constructor(options: GitlabStatus.GitlabCredentialStatusManagerOptions) {
     const {
@@ -67,7 +64,6 @@ class MockGitlabCredentialStatusManager extends GitlabStatus.GitlabCredentialSta
     });
     this.statusCredential = {} as VerifiableCredential;
     this.statusConfig = {} as CredentialStatusConfigData;
-    this.statusLog = [];
   }
 
   // generates new status list ID
@@ -107,21 +103,6 @@ class MockGitlabCredentialStatusManager extends GitlabStatus.GitlabCredentialSta
   // updates data in config file
   async updateConfigData(data: CredentialStatusConfigData): Promise<void> {
     this.statusConfig = data;
-  }
-
-  // creates data in log file
-  async createLogData(data: CredentialStatusLogData): Promise<void> {
-    this.statusLog = data;
-  }
-
-  // retrieves data from log file
-  async readLogData(): Promise<CredentialStatusLogData> {
-    return this.statusLog;
-  }
-
-  // updates data in log file
-  async updateLogData(data: CredentialStatusLogData): Promise<void> {
-    this.statusLog = data;
   }
 
   // creates data in status file

--- a/test/credential-status-manager-gitlab.spec.ts
+++ b/test/credential-status-manager-gitlab.spec.ts
@@ -79,7 +79,7 @@ class MockGitlabCredentialStatusManager extends GitlabStatus.GitlabCredentialSta
   async deployCredentialStatusWebsite(): Promise<void> {}
 
   // checks if caller has authority to update status based on status repo access token
-  async hasStatusAuthority(repoAccessToken: string): Promise<boolean> { return true; }
+  async hasStatusAuthority(repoAccessToken: string, metaRepoAccessToken?: string): Promise<boolean> { return true; }
 
   // checks if status repos exist
   async statusReposExist(): Promise<boolean> { return true; }

--- a/test/credential-status-manager-gitlab.spec.ts
+++ b/test/credential-status-manager-gitlab.spec.ts
@@ -11,7 +11,8 @@ import {
   BaseCredentialStatusManager,
   CredentialState,
   CredentialStatusConfigData,
-  CredentialStatusManagerService
+  CredentialStatusManagerService,
+  CredentialStatusSnapshotData
 } from '../src/credential-status-manager-base.js';
 import * as GitlabStatus from '../src/credential-status-manager-gitlab.js';
 import {
@@ -37,7 +38,8 @@ const sandbox = createSandbox();
 
 class MockGitlabCredentialStatusManager extends GitlabStatus.GitlabCredentialStatusManager {
   private statusCredential: VerifiableCredential;
-  private statusConfig: CredentialStatusConfigData;
+  private config: CredentialStatusConfigData;
+  private snapshot: CredentialStatusSnapshotData;
 
   constructor(options: GitlabStatus.GitlabCredentialStatusManagerOptions) {
     const {
@@ -63,7 +65,8 @@ class MockGitlabCredentialStatusManager extends GitlabStatus.GitlabCredentialSta
       didSeed
     });
     this.statusCredential = {} as VerifiableCredential;
-    this.statusConfig = {} as CredentialStatusConfigData;
+    this.config = {} as CredentialStatusConfigData;
+    this.snapshot = {} as CredentialStatusSnapshotData;
   }
 
   // generates new status credential ID
@@ -83,6 +86,11 @@ class MockGitlabCredentialStatusManager extends GitlabStatus.GitlabCredentialSta
   // retrieves data from status repo
   async readRepoData(): Promise<any> {
     throw new Error();
+  }
+
+  // retrieves file names from repo data
+  async readRepoFilenames(): Promise<string[]> {
+    return [statusCredentialId];
   }
 
   // retrieves data from status metadata repo
@@ -105,19 +113,49 @@ class MockGitlabCredentialStatusManager extends GitlabStatus.GitlabCredentialSta
     this.statusCredential = data;
   }
 
+  // deletes data in status files
+  async deleteStatusData(): Promise<void> {
+    this.statusCredential = {} as VerifiableCredential;
+  }
+
   // creates data in config file
   async createConfigData(data: CredentialStatusConfigData): Promise<void> {
-    this.statusConfig = data;
+    this.config = data;
   }
 
   // retrieves data from config file
   async readConfigData(): Promise<CredentialStatusConfigData> {
-    return this.statusConfig;
+    return this.config;
   }
 
   // updates data in config file
   async updateConfigData(data: CredentialStatusConfigData): Promise<void> {
-    this.statusConfig = data;
+    this.config = data;
+  }
+
+  // deletes data in config file
+  async deleteConfigData(): Promise<void> {
+    this.config = {} as CredentialStatusConfigData;
+  }
+
+  // creates data in snapshot file
+  async createSnapshotData(data: CredentialStatusSnapshotData): Promise<void> {
+    this.snapshot = data;
+  }
+
+  // retrieves data from snapshot file
+  async readSnapshotData(): Promise<CredentialStatusSnapshotData> {
+    return this.snapshot;
+  }
+
+  // deletes data in snapshot file
+  async deleteSnapshotData(): Promise<void> {
+    this.snapshot = {} as CredentialStatusSnapshotData;
+  }
+
+  // checks if snapshot data exists
+  async snapshotDataExists(): Promise<boolean> {
+    return Object.entries(this.snapshot).length !== 0;
   }
 }
 

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -79,7 +79,7 @@ export function checkLocalCredentialStatus(
   expect(credentialWithStatus.credentialStatus).to.have.property('statusListCredential');
   expect(credentialWithStatus.credentialStatus.type).to.equal('StatusList2021Entry');
   expect(credentialWithStatus.credentialStatus.statusPurpose).to.equal('revocation');
-  expect(credentialWithStatus.credentialStatus.statusListIndex).to.equal(credentialStatusIndex);
+  expect(credentialWithStatus.credentialStatus.statusListIndex).to.equal(credentialStatusIndex.toString());
   expect(credentialWithStatus.credentialStatus.id.startsWith(statusCredentialUrl)).to.be.true;
   expect(credentialWithStatus.credentialStatus.statusListCredential.startsWith(statusCredentialUrl)).to.be.true;
 }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -64,10 +64,10 @@ export function checkLocalCredentialStatus(
 ) {
   let statusCredentialUrl;
   switch (service) {
-    case CredentialStatusManagerService.Github:
+    case CredentialStatusManagerService.GitHub:
       statusCredentialUrl = `https://${ownerAccountName}.github.io/${repoName}/${statusCredentialId}`;
       break;
-    case CredentialStatusManagerService.Gitlab:
+    case CredentialStatusManagerService.GitLab:
       statusCredentialUrl = `https://${ownerAccountName}.gitlab.io/${repoName}/${statusCredentialId}`;
       break;
   }
@@ -112,10 +112,10 @@ export function checkStatusCredential(
 ) {
   let statusCredentialUrl;
   switch (service) {
-    case CredentialStatusManagerService.Github:
+    case CredentialStatusManagerService.GitHub:
       statusCredentialUrl = `https://${ownerAccountName}.github.io/${repoName}/${statusCredentialId}`;
       break;
-    case CredentialStatusManagerService.Gitlab:
+    case CredentialStatusManagerService.GitLab:
       statusCredentialUrl = `https://${ownerAccountName}.gitlab.io/${repoName}/${statusCredentialId}`;
       break;
   }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -52,20 +52,20 @@ export const repoAccessToken = 'abc123';
 export const metaRepoAccessToken = 'def456';
 export const didMethod = 'key' as DidMethod;
 export const didSeed = 'DsnrHBHFQP0ab59dQELh3uEwy7i5ArcOTwxkwRO2hM87CBRGWBEChPO7AjmwkAZ2';
-export const statusListId = 'V27UAUYPNR';
+export const statusCredentialId = 'V27UAUYPNR';
 
 export function checkLocalCredentialStatus(
   credentialWithStatus: any,
-  statusListIndex: number,
+  credentialStatusIndex: number,
   service: CredentialStatusManagerService
 ) {
-  let statusCredentialId;
+  let statusCredentialUrl;
   switch (service) {
     case CredentialStatusManagerService.Github:
-      statusCredentialId = `https://${ownerAccountName}.github.io/${repoName}/${statusListId}`;
+      statusCredentialUrl = `https://${ownerAccountName}.github.io/${repoName}/${statusCredentialId}`;
       break;
     case CredentialStatusManagerService.Gitlab:
-      statusCredentialId = `https://${ownerAccountName}.gitlab.io/${repoName}/${statusListId}`;
+      statusCredentialUrl = `https://${ownerAccountName}.gitlab.io/${repoName}/${statusCredentialId}`;
       break;
   }
   expect(credentialWithStatus).to.have.property('credentialStatus');
@@ -76,15 +76,15 @@ export function checkLocalCredentialStatus(
   expect(credentialWithStatus.credentialStatus).to.have.property('statusListCredential');
   expect(credentialWithStatus.credentialStatus.type).to.equal('StatusList2021Entry');
   expect(credentialWithStatus.credentialStatus.statusPurpose).to.equal('revocation');
-  expect(credentialWithStatus.credentialStatus.statusListIndex).to.equal(statusListIndex);
-  expect(credentialWithStatus.credentialStatus.id.startsWith(statusCredentialId)).to.be.true;
-  expect(credentialWithStatus.credentialStatus.statusListCredential.startsWith(statusCredentialId)).to.be.true;
+  expect(credentialWithStatus.credentialStatus.statusListIndex).to.equal(credentialStatusIndex);
+  expect(credentialWithStatus.credentialStatus.id.startsWith(statusCredentialUrl)).to.be.true;
+  expect(credentialWithStatus.credentialStatus.statusListCredential.startsWith(statusCredentialUrl)).to.be.true;
 }
 
 export function checkRemoteCredentialStatus(
   credentialStatus: any,
   credentialId: string,
-  statusListIndex: number
+  credentialStatusIndex: number
 ) {
   expect(credentialStatus).to.have.property('timestamp');
   expect(credentialStatus).to.have.property('credentialId');
@@ -92,28 +92,28 @@ export function checkRemoteCredentialStatus(
   expect(credentialStatus).to.have.property('credentialSubject');
   expect(credentialStatus).to.have.property('credentialState');
   expect(credentialStatus).to.have.property('verificationMethod');
-  expect(credentialStatus).to.have.property('statusListId');
-  expect(credentialStatus).to.have.property('statusListIndex');
+  expect(credentialStatus).to.have.property('statusCredentialId');
+  expect(credentialStatus).to.have.property('credentialStatusIndex');
   expect(credentialStatus.credentialId).to.equal(credentialId);
   expect(credentialStatus.credentialIssuer).to.equal(issuerDid);
   expect(credentialStatus.credentialSubject).to.equal(credentialSubject);
   expect(credentialStatus.credentialState).to.equal('revoked');
   expect(credentialStatus.verificationMethod).to.equal(verificationMethod);
-  expect(credentialStatus.statusListId).to.equal(statusListId);
-  expect(credentialStatus.statusListIndex).to.equal(statusListIndex);
+  expect(credentialStatus.statusCredentialId).to.equal(statusCredentialId);
+  expect(credentialStatus.credentialStatusIndex).to.equal(credentialStatusIndex);
 }
 
 export function checkStatusCredential(
   statusCredential: any,
   service: CredentialStatusManagerService
 ) {
-  let statusCredentialId;
+  let statusCredentialUrl;
   switch (service) {
     case CredentialStatusManagerService.Github:
-      statusCredentialId = `https://${ownerAccountName}.github.io/${repoName}/${statusListId}`;
+      statusCredentialUrl = `https://${ownerAccountName}.github.io/${repoName}/${statusCredentialId}`;
       break;
     case CredentialStatusManagerService.Gitlab:
-      statusCredentialId = `https://${ownerAccountName}.gitlab.io/${repoName}/${statusListId}`;
+      statusCredentialUrl = `https://${ownerAccountName}.gitlab.io/${repoName}/${statusCredentialId}`;
       break;
   }
   expect(statusCredential).to.have.property('id');
@@ -123,9 +123,9 @@ export function checkStatusCredential(
   expect(statusCredential.credentialSubject).to.have.property('type');
   expect(statusCredential.credentialSubject).to.have.property('encodedList');
   expect(statusCredential.credentialSubject).to.have.property('statusPurpose');
-  expect(statusCredential.id).to.equal(statusCredentialId);
+  expect(statusCredential.id).to.equal(statusCredentialUrl);
   expect(statusCredential.type).to.include('StatusList2021Credential');
-  expect(statusCredential.credentialSubject.id.startsWith(statusCredentialId)).to.be.true;
+  expect(statusCredential.credentialSubject.id.startsWith(statusCredentialUrl)).to.be.true;
   expect(statusCredential.credentialSubject.type).to.equal('StatusList2021');
   expect(statusCredential.credentialSubject.statusPurpose).to.equal('revocation');
 }


### PR DESCRIPTION
This PR implements a fault recovery mechanism per Issue #14.

The main update is the introduction of a snapshot file that is to be created and temporarily saved in the metadata repo after acquiring a lock and rolling back incomplete/disrupted transactions and before executing any data modifying operations in a transactional function. In the event of runtime transaction disruptions caused by network issues, the snapshot data is restored on restart when `createStatusManager` is called. For disruptions that do not result in an exit of the transaction, the transaction is retried after the snapshot data is restored and the lock is released for starvation relief.

Additionally, I made some data model changes to support this functionality.