### PR TITLE
Display missing options when not correctly configured

### DIFF
--- a/src/credential-status-manager-github.ts
+++ b/src/credential-status-manager-github.ts
@@ -75,7 +75,7 @@ export class GithubCredentialStatusManager extends BaseCredentialStatusManager {
     const isProperlyConfigured = GITHUB_MANAGER_REQUIRED_OPTIONS.every(
       (option: keyof GithubCredentialStatusManagerOptions) => {
         if (!options[option]) {
-          missingOptions.push();
+          missingOptions.push(option);
         }
         return !!options[option];
       }


### PR DESCRIPTION
While setting this up, I noticed that the output was not very helpful when I didn't add all the correct options! 
![image](https://github.com/digitalcredentials/credential-status-manager-git/assets/39720479/e5dff8b6-3b3a-49a6-acb0-74082260da28)

This fixes that 🤓