### PR TITLE
Use strings for Status List Index

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,24 +5,26 @@ A Typescript library for managing the status of [Verifiable Credentials](https:/
 [![Build status](https://img.shields.io/github/actions/workflow/status/digitalcredentials/credential-status-manager-git/main.yml?branch=main)](https://github.com/digitalcredentials/credential-status-manager-git/actions?query=workflow%3A%22Node.js+CI%22)
 [![NPM Version](https://img.shields.io/npm/v/@digitalcredentials/credential-status-manager-git.svg)](https://npm.im/@digitalcredentials/credential-status-manager-git)
 
-## Table of Contents
+# Table of Contents
 
-- [Background](#background)
-- [Install](#install)
-  - [NPM](#npm)
-  - [Development](#development)
-- [Usage](#usage)
-  - [Create credential status manager](#create-credential-status-manager)
-  - [Allocate status for credential](#allocate-status-for-credential)
-  - [Update status of credential](#update-status-of-credential)
-  - [Check status of credential](#check-status-of-credential)
-  - [Check if caller has authority to update status of credentials](#check-if-caller-has-authority-to-update-status-of-credentials)
-- [Dependencies](#Dependencies)
-  - [Create credential status repositories](#create-credential-status-repositories)
-  - [Generate access tokens](#generate-access-tokens)
-  - [Generate DID seeds](#generate-did-seeds)
-- [Contribute](#contribute)
-- [License](#license)
+- [credential-status-manager-git](#credential-status-manager-git)
+- [Table of Contents](#table-of-contents)
+    - [Background](#background)
+    - [Install](#install)
+        - [NPM](#npm)
+        - [Development](#development)
+    - [Usage](#usage)
+        - [Create credential status manager](#create-credential-status-manager)
+        - [Allocate status for credential](#allocate-status-for-credential)
+        - [Update status of credential](#update-status-of-credential)
+        - [Check status of credential](#check-status-of-credential)
+        - [Check if caller has authority to update status of credentials](#check-if-caller-has-authority-to-update-status-of-credentials)
+    - [Dependencies](#dependencies)
+        - [Create credential status repositories](#create-credential-status-repositories)
+        - [Generate access tokens](#generate-access-tokens)
+        - [Generate DID seeds](#generate-did-seeds)
+    - [Contribute](#contribute)
+    - [License](#license)
 
 ## Background
 
@@ -132,7 +134,7 @@ console.log(credentialWithStatus);
     id: 'https://university-xyz.github.io/credential-status/V27UAUYPNR#1',
     type: 'StatusList2021Entry',
     statusPurpose: 'revocation',
-    statusListIndex: 1,
+    statusListIndex: '1',
     statusListCredential: 'https://university-xyz.github.io/credential-status/V27UAUYPNR'
   }
 }
@@ -191,7 +193,7 @@ console.log(credentialStatus);
   credentialState: 'revoked',
   verificationMethod: 'did:key:z6MkhVTX9BF3NGYX6cc7jWpbNnR7cAjH8LUffabZP8Qu4ysC#z6MkhVTX9BF3NGYX6cc7jWpbNnR7cAjH8LUffabZP8Qu4ysC',
   statusListId: 'V27UAUYPNR',
-  statusListIndex: 1
+  statusListIndex: '1'
 }
 */
 ```

--- a/src/credential-status-manager-base.ts
+++ b/src/credential-status-manager-base.ts
@@ -7,10 +7,10 @@ import { createCredential, createList, decodeList } from '@digitalcredentials/vc
 import { Mutex } from 'async-mutex';
 import { v4 as uuid } from 'uuid';
 import {
-  DidMethod,
-  getDateString,
-  getSigningMaterial,
-  signCredential
+    DidMethod,
+    getDateString,
+    getSigningMaterial,
+    signCredential
 } from './helpers.js';
 
 // Number of credentials tracked in a list
@@ -28,39 +28,39 @@ export const CREDENTIAL_STATUS_LOG_FILE = 'log.json';
 
 // Credential status manager source control service
 export enum CredentialStatusManagerService {
-  Github = 'github',
-  Gitlab = 'gitlab'
+    Github = 'github',
+    Gitlab = 'gitlab'
 }
 
 // Actions applied to credentials and tracked in status log
 export enum SystemFile {
-  Config = 'config',
-  Log = 'log',
-  Status = 'status'
+    Config = 'config',
+    Log = 'log',
+    Status = 'status'
 }
 
 // States of credential resulting from caller actions and tracked in status log
 export enum CredentialState {
-  Active = 'active',
-  Revoked = 'revoked'
+    Active = 'active',
+    Revoked = 'revoked'
 }
 
 // Type definition for credential status config file
 export interface CredentialStatusConfigData {
-  credentialsIssued: number;
-  latestList: string;
+    credentialsIssued: number;
+    latestList: string;
 }
 
 // Type definition for credential status log entry
 export interface CredentialStatusLogEntry {
-  timestamp: string;
-  credentialId: string;
-  credentialIssuer: string;
-  credentialSubject?: string;
-  credentialState: CredentialState;
-  verificationMethod: string;
-  statusListId: string;
-  statusListIndex: number;
+    timestamp: string;
+    credentialId: string;
+    credentialIssuer: string;
+    credentialSubject?: string;
+    credentialState: CredentialState;
+    verificationMethod: string;
+    statusListId: string;
+    statusListIndex: number;
 }
 
 // Type definition for credential status log
@@ -68,538 +68,538 @@ export type CredentialStatusLogData = CredentialStatusLogEntry[];
 
 // Type definition for composeStatusCredential function input
 interface ComposeStatusCredentialOptions {
-  issuerDid: string;
-  credentialId: string;
-  statusList?: any;
-  statusPurpose?: string;
+    issuerDid: string;
+    credentialId: string;
+    statusList?: any;
+    statusPurpose?: string;
 }
 
 // Type definition for embedCredentialStatus method input
 interface EmbedCredentialStatusOptions {
-  credential: any;
-  statusPurpose?: string;
+    credential: any;
+    statusPurpose?: string;
 }
 
 // Type definition for embedCredentialStatus method output
 interface EmbedCredentialStatusResult {
-  credential: any;
-  newList?: string;
+    credential: any;
+    newList?: string;
 }
 
 // Type definition for updateStatus method input
 interface UpdateStatusOptions {
-  credentialId: string;
-  credentialStatus: CredentialState;
+    credentialId: string;
+    credentialStatus: CredentialState;
 }
 
 // Type definition for BaseCredentialStatusManager constructor method input
 export interface BaseCredentialStatusManagerOptions {
-  repoName: string;
-  metaRepoName: string;
-  repoAccessToken: string;
-  metaRepoAccessToken: string;
-  didMethod: DidMethod;
-  didSeed: string;
-  didWebUrl?: string;
-  signUserCredential?: boolean;
-  signStatusCredential?: boolean;
+    repoName: string;
+    metaRepoName: string;
+    repoAccessToken: string;
+    metaRepoAccessToken: string;
+    didMethod: DidMethod;
+    didSeed: string;
+    didWebUrl?: string;
+    signUserCredential?: boolean;
+    signStatusCredential?: boolean;
 }
 
 // Minimal set of options required for configuring BaseCredentialStatusManager
 export const BASE_MANAGER_REQUIRED_OPTIONS: Array<keyof BaseCredentialStatusManagerOptions> = [
-  'repoName',
-  'metaRepoName',
-  'repoAccessToken',
-  'metaRepoAccessToken',
-  'didMethod',
-  'didSeed'
+    'repoName',
+    'metaRepoName',
+    'repoAccessToken',
+    'metaRepoAccessToken',
+    'didMethod',
+    'didSeed'
 ];
 
 // Base class for credential status managers
 export abstract class BaseCredentialStatusManager {
-  protected readonly repoName: string;
-  protected readonly metaRepoName: string;
-  protected readonly repoAccessToken: string;
-  protected readonly metaRepoAccessToken: string;
-  protected readonly didMethod: DidMethod;
-  protected readonly didSeed: string;
-  protected readonly didWebUrl: string;
-  protected readonly signUserCredential: boolean;
-  protected readonly signStatusCredential: boolean;
-  protected readonly lock: Mutex;
+    protected readonly repoName: string;
+    protected readonly metaRepoName: string;
+    protected readonly repoAccessToken: string;
+    protected readonly metaRepoAccessToken: string;
+    protected readonly didMethod: DidMethod;
+    protected readonly didSeed: string;
+    protected readonly didWebUrl: string;
+    protected readonly signUserCredential: boolean;
+    protected readonly signStatusCredential: boolean;
+    protected readonly lock: Mutex;
 
-  constructor(options: BaseCredentialStatusManagerOptions) {
-    const {
-      repoName,
-      metaRepoName,
-      repoAccessToken,
-      metaRepoAccessToken,
-      didMethod,
-      didSeed,
-      didWebUrl,
-      signUserCredential,
-      signStatusCredential
-    } = options;
-    this.repoName = repoName;
-    this.metaRepoName = metaRepoName;
-    this.repoAccessToken = repoAccessToken;
-    this.metaRepoAccessToken = metaRepoAccessToken;
-    this.didMethod = didMethod;
-    this.didSeed = didSeed;
-    this.didWebUrl = didWebUrl ?? '';
-    this.signUserCredential = signUserCredential ?? false;
-    this.signStatusCredential = signStatusCredential ?? false;
-    this.lock = new Mutex();
-  }
-
-  // generates new status list ID
-  generateStatusListId(): string {
-    return Math.random().toString(36).substring(2, 12).toUpperCase();
-  }
-
-  // embeds status into credential
-  async embedCredentialStatus({ credential, statusPurpose = 'revocation' }: EmbedCredentialStatusOptions): Promise<EmbedCredentialStatusResult> {
-    // ensure that credential has ID
-    if (!credential.id) {
-      // Note: This assumes that uuid will never generate an ID that
-      // conflicts with an ID that has already been tracked in the log
-      credential.id = uuid();
+    constructor(options: BaseCredentialStatusManagerOptions) {
+        const {
+            repoName,
+            metaRepoName,
+            repoAccessToken,
+            metaRepoAccessToken,
+            didMethod,
+            didSeed,
+            didWebUrl,
+            signUserCredential,
+            signStatusCredential
+        } = options;
+        this.repoName = repoName;
+        this.metaRepoName = metaRepoName;
+        this.repoAccessToken = repoAccessToken;
+        this.metaRepoAccessToken = metaRepoAccessToken;
+        this.didMethod = didMethod;
+        this.didSeed = didSeed;
+        this.didWebUrl = didWebUrl ?? '';
+        this.signUserCredential = signUserCredential ?? false;
+        this.signStatusCredential = signStatusCredential ?? false;
+        this.lock = new Mutex();
     }
 
-    // find latest relevant log entry for credential with given ID
-    const logData: CredentialStatusLogData = await this.readLogData();
-    logData.reverse();
-    const logEntry = logData.find((entry) => {
-      return entry.credentialId === credential.id;
-    });
+    // generates new status list ID
+    generateStatusListId(): string {
+        return Math.random().toString(36).substring(2, 12).toUpperCase();
+    }
 
-    // do not allocate new status list entry if ID is already being tracked
-    if (logEntry) {
-      // retrieve relevant log data
-      const { statusListId: logStatusListId, statusListIndex } = logEntry;
-
-      // attach credential status
-      const statusUrl = this.getCredentialStatusUrl();
-      const statusListCredential = `${statusUrl}/${logStatusListId}`;
-      const statusListId = `${statusListCredential}#${statusListIndex}`;
-      const credentialStatus = {
-        id: statusListId,
-        type: CREDENTIAL_STATUS_TYPE,
-        statusPurpose,
-        statusListIndex: statusListIndex.toString(),
-        statusListCredential
-      };
-
-      return {
-        credential: {
-          ...credential,
-          credentialStatus,
-          '@context': [...credential['@context'], CONTEXT_URL_V1]
+    // embeds status into credential
+    async embedCredentialStatus({ credential, statusPurpose = 'revocation' }: EmbedCredentialStatusOptions): Promise<EmbedCredentialStatusResult> {
+        // ensure that credential has ID
+        if (!credential.id) {
+            // Note: This assumes that uuid will never generate an ID that
+            // conflicts with an ID that has already been tracked in the log
+            credential.id = uuid();
         }
-      };
-    }
 
-    // retrieve status config data
-    const configData = await this.readConfigData();
-    let { credentialsIssued, latestList } = configData;
-
-    // allocate new status list entry if ID is not yet being tracked
-    let newList;
-    if (credentialsIssued >= CREDENTIAL_STATUS_LIST_SIZE) {
-      latestList = this.generateStatusListId();
-      newList = latestList;
-      credentialsIssued = 0;
-    }
-    credentialsIssued++;
-
-    // update status config data
-    configData.credentialsIssued = credentialsIssued;
-    configData.latestList = latestList;
-    await this.updateConfigData(configData);
-
-    // attach credential status
-    const statusUrl = this.getCredentialStatusUrl();
-    const statusListCredential = `${statusUrl}/${latestList}`;
-    const statusListIndex = credentialsIssued.toString(); 
-    const statusListId = `${statusListCredential}#${statusListIndex}`;
-    const credentialStatus = {
-      id: statusListId,
-      type: CREDENTIAL_STATUS_TYPE,
-      statusPurpose,
-      statusListIndex,
-      statusListCredential
-    };
-
-    return {
-      credential: {
-        ...credential,
-        credentialStatus,
-        '@context': [...credential['@context'], CONTEXT_URL_V1]
-      },
-      newList
-    };
-  }
-
-  // allocates status for credential in race-prone manner
-  async allocateStatusUnsafe(credential: VerifiableCredential): Promise<VerifiableCredential> {
-    // report error for compact JWT credentials
-    if (typeof credential === 'string') {
-      throw new Error('This library does not support compact JWT credentials.');
-    }
-
-    // attach status to credential
-    let {
-      credential: credentialWithStatus,
-      newList
-    } = await this.embedCredentialStatus({ credential });
-
-    // retrieve signing material
-    const {
-      didMethod,
-      didSeed,
-      didWebUrl,
-      signUserCredential,
-      signStatusCredential
-    } = this;
-    const {
-      issuerDid,
-      verificationMethod
-    } = await getSigningMaterial({
-      didMethod,
-      didSeed,
-      didWebUrl
-    });
-
-    // create new status credential only if a new list was created
-    if (newList) {
-      // create status credential
-      const credentialStatusUrl = this.getCredentialStatusUrl();
-      const statusCredentialId = `${credentialStatusUrl}/${newList}`;
-      let statusCredential = await composeStatusCredential({
-        issuerDid,
-        credentialId: statusCredentialId
-      });
-
-      // sign status credential if necessary
-      if (signStatusCredential) {
-        statusCredential = await signCredential({
-          credential: statusCredential,
-          didMethod,
-          didSeed,
-          didWebUrl
+        // find latest relevant log entry for credential with given ID
+        const logData: CredentialStatusLogData = await this.readLogData();
+        logData.reverse();
+        const logEntry = logData.find((entry) => {
+            return entry.credentialId === credential.id;
         });
-      }
 
-      // create and persist status data
-      await this.createStatusData(statusCredential);
+        // do not allocate new status list entry if ID is already being tracked
+        if (logEntry) {
+            // retrieve relevant log data
+            const { statusListId: logStatusListId, statusListIndex } = logEntry;
+
+            // attach credential status
+            const statusUrl = this.getCredentialStatusUrl();
+            const statusListCredential = `${statusUrl}/${logStatusListId}`;
+            const statusListId = `${statusListCredential}#${statusListIndex}`;
+            const credentialStatus = {
+                id: statusListId,
+                type: CREDENTIAL_STATUS_TYPE,
+                statusPurpose,
+                statusListIndex: statusListIndex.toString(),
+                statusListCredential
+            };
+
+            return {
+                credential: {
+                    ...credential,
+                    credentialStatus,
+                    '@context': [...credential['@context'], CONTEXT_URL_V1]
+                }
+            };
+        }
+
+        // retrieve status config data
+        const configData = await this.readConfigData();
+        let { credentialsIssued, latestList } = configData;
+
+        // allocate new status list entry if ID is not yet being tracked
+        let newList;
+        if (credentialsIssued >= CREDENTIAL_STATUS_LIST_SIZE) {
+            latestList = this.generateStatusListId();
+            newList = latestList;
+            credentialsIssued = 0;
+        }
+        credentialsIssued++;
+
+        // update status config data
+        configData.credentialsIssued = credentialsIssued;
+        configData.latestList = latestList;
+        await this.updateConfigData(configData);
+
+        // attach credential status
+        const statusUrl = this.getCredentialStatusUrl();
+        const statusListCredential = `${statusUrl}/${latestList}`;
+        const statusListIndex = credentialsIssued.toString();
+        const statusListId = `${statusListCredential}#${statusListIndex}`;
+        const credentialStatus = {
+            id: statusListId,
+            type: CREDENTIAL_STATUS_TYPE,
+            statusPurpose,
+            statusListIndex,
+            statusListCredential
+        };
+
+        return {
+            credential: {
+                ...credential,
+                credentialStatus,
+                '@context': [...credential['@context'], CONTEXT_URL_V1]
+            },
+            newList
+        };
     }
 
-    if (signUserCredential) {
-      // sign credential
-      credentialWithStatus = await signCredential({
-        credential: credentialWithStatus,
-        didMethod,
-        didSeed,
-        didWebUrl
-      });
+    // allocates status for credential in race-prone manner
+    async allocateStatusUnsafe(credential: VerifiableCredential): Promise<VerifiableCredential> {
+        // report error for compact JWT credentials
+        if (typeof credential === 'string') {
+            throw new Error('This library does not support compact JWT credentials.');
+        }
+
+        // attach status to credential
+        let {
+            credential: credentialWithStatus,
+            newList
+        } = await this.embedCredentialStatus({ credential });
+
+        // retrieve signing material
+        const {
+            didMethod,
+            didSeed,
+            didWebUrl,
+            signUserCredential,
+            signStatusCredential
+        } = this;
+        const {
+            issuerDid,
+            verificationMethod
+        } = await getSigningMaterial({
+            didMethod,
+            didSeed,
+            didWebUrl
+        });
+
+        // create new status credential only if a new list was created
+        if (newList) {
+            // create status credential
+            const credentialStatusUrl = this.getCredentialStatusUrl();
+            const statusCredentialId = `${credentialStatusUrl}/${newList}`;
+            let statusCredential = await composeStatusCredential({
+                issuerDid,
+                credentialId: statusCredentialId
+            });
+
+            // sign status credential if necessary
+            if (signStatusCredential) {
+                statusCredential = await signCredential({
+                    credential: statusCredential,
+                    didMethod,
+                    didSeed,
+                    didWebUrl
+                });
+            }
+
+            // create and persist status data
+            await this.createStatusData(statusCredential);
+        }
+
+        if (signUserCredential) {
+            // sign credential
+            credentialWithStatus = await signCredential({
+                credential: credentialWithStatus,
+                didMethod,
+                didSeed,
+                didWebUrl
+            });
+        }
+
+        // add new entry to status log
+        const {
+            id: credentialStatusId,
+            statusListCredential,
+            statusListIndex
+        } = credentialWithStatus.credentialStatus;
+
+        // retrieve status list ID from status credential URL
+        const statusListId = statusListCredential.split('/').slice(-1).pop();
+        const statusLogEntry: CredentialStatusLogEntry = {
+            timestamp: getDateString(),
+            credentialId: credential.id ?? credentialStatusId,
+            credentialIssuer: issuerDid,
+            credentialSubject: credential.credentialSubject?.id,
+            credentialState: CredentialState.Active,
+            verificationMethod,
+            statusListId,
+            statusListIndex
+        };
+        const statusLogData = await this.readLogData();
+        statusLogData.push(statusLogEntry);
+        await this.updateLogData(statusLogData);
+
+        return credentialWithStatus;
     }
 
-    // add new entry to status log
-    const {
-      id: credentialStatusId,
-      statusListCredential,
-      statusListIndex
-    } = credentialWithStatus.credentialStatus;
-
-    // retrieve status list ID from status credential URL
-    const statusListId = statusListCredential.split('/').slice(-1).pop();
-    const statusLogEntry: CredentialStatusLogEntry = {
-      timestamp: getDateString(),
-      credentialId: credential.id ?? credentialStatusId,
-      credentialIssuer: issuerDid,
-      credentialSubject: credential.credentialSubject?.id,
-      credentialState: CredentialState.Active,
-      verificationMethod,
-      statusListId,
-      statusListIndex
-    };
-    const statusLogData = await this.readLogData();
-    statusLogData.push(statusLogEntry);
-    await this.updateLogData(statusLogData);
-
-    return credentialWithStatus;
-  }
-
-  // allocates status for credential in thread-safe manner
-  async allocateStatus(credential: VerifiableCredential): Promise<VerifiableCredential> {
-    const release = await this.lock.acquire();
-    try {
-      const result = await this.allocateStatusUnsafe(credential);
-      return result;
-    } finally {
-      release();
-    }
-  }
-
-  // updates status of credential in race-prone manner
-  async updateStatusUnsafe({
-    credentialId,
-    credentialStatus
-  }: UpdateStatusOptions): Promise<VerifiableCredential> {
-    // find latest relevant log entry for credential with given ID
-    const logData: CredentialStatusLogData = await this.readLogData();
-    logData.reverse();
-    const logEntry = logData.find((entry) => {
-      return entry.credentialId === credentialId;
-    });
-
-    // unable to find credential with given ID
-    if (!logEntry) {
-      throw new Error(`Unable to find credential with given ID "${credentialId}"`);
+    // allocates status for credential in thread-safe manner
+    async allocateStatus(credential: VerifiableCredential): Promise<VerifiableCredential> {
+        const release = await this.lock.acquire();
+        try {
+            const result = await this.allocateStatusUnsafe(credential);
+            return result;
+        } finally {
+            release();
+        }
     }
 
-    // retrieve relevant log data
-    const {
-      credentialSubject,
-      statusListId,
-      statusListIndex
-    } = logEntry;
+    // updates status of credential in race-prone manner
+    async updateStatusUnsafe({
+        credentialId,
+        credentialStatus
+    }: UpdateStatusOptions): Promise<VerifiableCredential> {
+        // find latest relevant log entry for credential with given ID
+        const logData: CredentialStatusLogData = await this.readLogData();
+        logData.reverse();
+        const logEntry = logData.find((entry) => {
+            return entry.credentialId === credentialId;
+        });
 
-    // retrieve signing material
-    const {
-      didMethod,
-      didSeed,
-      didWebUrl,
-      signStatusCredential
-    } = this;
-    const {
-      issuerDid,
-      verificationMethod
-    } = await getSigningMaterial({
-      didMethod,
-      didSeed,
-      didWebUrl
-    });
+        // unable to find credential with given ID
+        if (!logEntry) {
+            throw new Error(`Unable to find credential with given ID "${credentialId}"`);
+        }
 
-    // retrieve status credential
-    const statusCredentialBefore = await this.readStatusData();
+        // retrieve relevant log data
+        const {
+            credentialSubject,
+            statusListId,
+            statusListIndex
+        } = logEntry;
 
-    // report error for compact JWT credentials
-    if (typeof statusCredentialBefore === 'string') {
-      throw new Error('This library does not support compact JWT credentials.');
+        // retrieve signing material
+        const {
+            didMethod,
+            didSeed,
+            didWebUrl,
+            signStatusCredential
+        } = this;
+        const {
+            issuerDid,
+            verificationMethod
+        } = await getSigningMaterial({
+            didMethod,
+            didSeed,
+            didWebUrl
+        });
+
+        // retrieve status credential
+        const statusCredentialBefore = await this.readStatusData();
+
+        // report error for compact JWT credentials
+        if (typeof statusCredentialBefore === 'string') {
+            throw new Error('This library does not support compact JWT credentials.');
+        }
+
+        // update status credential
+        const statusCredentialListEncodedBefore = statusCredentialBefore.credentialSubject.encodedList;
+        const statusCredentialListDecoded = await decodeList({
+            encodedList: statusCredentialListEncodedBefore
+        });
+        switch (credentialStatus) {
+            case CredentialState.Active:
+                statusCredentialListDecoded.setStatus(Number(statusListIndex), false); // active credential is represented as 0 bit
+                break;
+            case CredentialState.Revoked:
+                statusCredentialListDecoded.setStatus(Number(statusListIndex), true); // revoked credential is represented as 1 bit
+                break;
+            default:
+                throw new Error(
+                    '"credentialStatus" must be one of the following values: ' +
+                    `${Object.values(CredentialState).map(v => `'${v}'`).join(', ')}.`
+                );
+        }
+        const credentialStatusUrl = this.getCredentialStatusUrl();
+        const statusCredentialId = `${credentialStatusUrl}/${statusListId}`;
+        let statusCredential = await composeStatusCredential({
+            issuerDid,
+            credentialId: statusCredentialId,
+            statusList: statusCredentialListDecoded
+        });
+
+        // sign status credential if necessary
+        if (signStatusCredential) {
+            statusCredential = await signCredential({
+                credential: statusCredential,
+                didMethod,
+                didSeed,
+                didWebUrl
+            });
+        }
+
+        // persist status credential
+        await this.updateStatusData(statusCredential);
+
+        // add new entries to status log
+        const statusLogData = await this.readLogData();
+        const statusLogEntry: CredentialStatusLogEntry = {
+            timestamp: getDateString(),
+            credentialId,
+            credentialIssuer: issuerDid,
+            credentialSubject,
+            credentialState: credentialStatus,
+            verificationMethod,
+            statusListId,
+            statusListIndex
+        };
+        statusLogData.push(statusLogEntry);
+        await this.updateLogData(statusLogData);
+
+        return statusCredential;
     }
 
-    // update status credential
-    const statusCredentialListEncodedBefore = statusCredentialBefore.credentialSubject.encodedList;
-    const statusCredentialListDecoded = await decodeList({
-      encodedList: statusCredentialListEncodedBefore
-    });
-    switch (credentialStatus) {
-      case CredentialState.Active:
-        statusCredentialListDecoded.setStatus(statusListIndex, false); // active credential is represented as 0 bit
-        break;
-      case CredentialState.Revoked:
-        statusCredentialListDecoded.setStatus(statusListIndex, true); // revoked credential is represented as 1 bit
-        break;
-      default:
-        throw new Error(
-          '"credentialStatus" must be one of the following values: ' +
-          `${Object.values(CredentialState).map(v => `'${v}'`).join(', ')}.`
-        );
-    }
-    const credentialStatusUrl = this.getCredentialStatusUrl();
-    const statusCredentialId = `${credentialStatusUrl}/${statusListId}`;
-    let statusCredential = await composeStatusCredential({
-      issuerDid,
-      credentialId: statusCredentialId,
-      statusList: statusCredentialListDecoded
-    });
-
-    // sign status credential if necessary
-    if (signStatusCredential) {
-      statusCredential = await signCredential({
-        credential: statusCredential,
-        didMethod,
-        didSeed,
-        didWebUrl
-      });
+    // updates status of credential in thread-safe manner
+    async updateStatus({
+        credentialId,
+        credentialStatus
+    }: UpdateStatusOptions): Promise<VerifiableCredential> {
+        const release = await this.lock.acquire();
+        try {
+            const result = await this.updateStatusUnsafe({ credentialId, credentialStatus });
+            return result;
+        } finally {
+            release();
+        }
     }
 
-    // persist status credential
-    await this.updateStatusData(statusCredential);
+    // checks status of credential
+    async checkStatus(credentialId: string): Promise<CredentialStatusLogEntry> {
+        // find latest relevant log entry for credential with given ID
+        const logData: CredentialStatusLogData = await this.readLogData();
+        logData.reverse();
+        const logEntry = logData.find((entry) => {
+            return entry.credentialId === credentialId;
+        }) as CredentialStatusLogEntry;
 
-    // add new entries to status log
-    const statusLogData = await this.readLogData();
-    const statusLogEntry: CredentialStatusLogEntry = {
-      timestamp: getDateString(),
-      credentialId,
-      credentialIssuer: issuerDid,
-      credentialSubject,
-      credentialState: credentialStatus,
-      verificationMethod,
-      statusListId,
-      statusListIndex
-    };
-    statusLogData.push(statusLogEntry);
-    await this.updateLogData(statusLogData);
+        // unable to find credential with given ID
+        if (!logEntry) {
+            throw new Error(`Unable to find credential with given ID "${credentialId}"`);
+        }
 
-    return statusCredential;
-  }
-
-  // updates status of credential in thread-safe manner
-  async updateStatus({
-    credentialId,
-    credentialStatus
-  }: UpdateStatusOptions): Promise<VerifiableCredential> {
-    const release = await this.lock.acquire();
-    try {
-      const result = await this.updateStatusUnsafe({ credentialId, credentialStatus });
-      return result;
-    } finally {
-      release();
-    }
-  }
-
-  // checks status of credential
-  async checkStatus(credentialId: string): Promise<CredentialStatusLogEntry> {
-    // find latest relevant log entry for credential with given ID
-    const logData: CredentialStatusLogData = await this.readLogData();
-    logData.reverse();
-    const logEntry = logData.find((entry) => {
-      return entry.credentialId === credentialId;
-    }) as CredentialStatusLogEntry;
-
-    // unable to find credential with given ID
-    if (!logEntry) {
-      throw new Error(`Unable to find credential with given ID "${credentialId}"`);
+        return logEntry;
     }
 
-    return logEntry;
-  }
+    // retrieves credential status URL
+    abstract getCredentialStatusUrl(): string;
 
-  // retrieves credential status URL
-  abstract getCredentialStatusUrl(): string;
+    // deploys website to host credential status management resources
+    async deployCredentialStatusWebsite(): Promise<void> { };
 
-  // deploys website to host credential status management resources
-  async deployCredentialStatusWebsite(): Promise<void> {};
+    // checks if caller has authority to update status based on status repo access token
+    abstract hasStatusAuthority(repoAccessToken: string): Promise<boolean>;
 
-  // checks if caller has authority to update status based on status repo access token
-  abstract hasStatusAuthority(repoAccessToken: string): Promise<boolean>;
+    // checks if status repos exist
+    abstract statusReposExist(): Promise<boolean>;
 
-  // checks if status repos exist
-  abstract statusReposExist(): Promise<boolean>;
+    // checks if status repos are empty
+    abstract statusReposEmpty(): Promise<boolean>;
 
-  // checks if status repos are empty
-  abstract statusReposEmpty(): Promise<boolean>;
+    // checks if status repos are properly configured
+    async statusReposProperlyConfigured(): Promise<boolean> {
+        try {
+            // retrieve config data
+            const configData = await this.readConfigData();
+            const { credentialsIssued, latestList: statusListId } = configData;
+            const credentialStatusUrl = this.getCredentialStatusUrl();
+            const statusCredentialId = `${credentialStatusUrl}/${statusListId}`;
 
-  // checks if status repos are properly configured
-  async statusReposProperlyConfigured(): Promise<boolean> {
-    try {
-      // retrieve config data
-      const configData = await this.readConfigData();
-      const { credentialsIssued, latestList: statusListId } = configData;
-      const credentialStatusUrl = this.getCredentialStatusUrl();
-      const statusCredentialId = `${credentialStatusUrl}/${statusListId}`;
+            // retrieve log data
+            const logData = await this.readLogData();
 
-      // retrieve log data
-      const logData = await this.readLogData();
+            // retrieve status credential
+            const statusListData = await this.readStatusData();
 
-      // retrieve status credential
-      const statusListData = await this.readStatusData();
+            // ensure status data has proper type
+            if (typeof statusListData === 'string') {
+                return false;
+            }
 
-      // ensure status data has proper type
-      if (typeof statusListData === 'string') {
-        return false;
-      }
+            // ensure status credential is well formed
+            const hasProperStatusListId = statusListData.id?.endsWith(statusListId) ?? false;
+            const hasProperStatusListType = statusListData.type.includes('StatusList2021Credential');
+            const hasProperStatusListSubId = statusListData.credentialSubject.id?.startsWith(statusCredentialId) ?? false;
+            const hasProperStatusListSubType = statusListData.credentialSubject.type === 'StatusList2021';
+            const hasProperStatusListSubStatusPurpose = statusListData.credentialSubject.statusPurpose === 'revocation';
 
-      // ensure status credential is well formed
-      const hasProperStatusListId = statusListData.id?.endsWith(statusListId) ?? false;
-      const hasProperStatusListType = statusListData.type.includes('StatusList2021Credential');
-      const hasProperStatusListSubId = statusListData.credentialSubject.id?.startsWith(statusCredentialId) ?? false;
-      const hasProperStatusListSubType = statusListData.credentialSubject.type === 'StatusList2021';
-      const hasProperStatusListSubStatusPurpose = statusListData.credentialSubject.statusPurpose === 'revocation';
+            // ensure log data is well formed
+            const hasProperLogDataType = Array.isArray(logData);
+            const credentialIds = logData.map((value) => {
+                return value.credentialId;
+            });
+            const credentialIdsUnique = credentialIds.filter((value, index, array) => {
+                return array.indexOf(value) === index;
+            });
+            const hasProperLogEntries = credentialIdsUnique.length === credentialsIssued;
 
-      // ensure log data is well formed
-      const hasProperLogDataType = Array.isArray(logData);
-      const credentialIds = logData.map((value) => {
-        return value.credentialId;
-      });
-      const credentialIdsUnique = credentialIds.filter((value, index, array) => {
-        return array.indexOf(value) === index;
-      });
-      const hasProperLogEntries = credentialIdsUnique.length === credentialsIssued;
-
-      // ensure that all checks pass
-      return hasProperStatusListId &&
-             hasProperStatusListType &&
-             hasProperStatusListSubId &&
-             hasProperStatusListSubType &&
-             hasProperStatusListSubStatusPurpose &&
-             hasProperLogDataType &&
-             hasProperLogEntries;
-    } catch (error) {
-      return false;
+            // ensure that all checks pass
+            return hasProperStatusListId &&
+                hasProperStatusListType &&
+                hasProperStatusListSubId &&
+                hasProperStatusListSubType &&
+                hasProperStatusListSubStatusPurpose &&
+                hasProperLogDataType &&
+                hasProperLogEntries;
+        } catch (error) {
+            return false;
+        }
     }
-  }
 
-  // retrieves data from status repo
-  abstract readRepoData(): Promise<any>;
+    // retrieves data from status repo
+    abstract readRepoData(): Promise<any>;
 
-  // retrieves data from status metadata repo
-  abstract readMetaRepoData(): Promise<any>;
+    // retrieves data from status metadata repo
+    abstract readMetaRepoData(): Promise<any>;
 
-  // creates data in config file
-  abstract createConfigData(data: CredentialStatusConfigData): Promise<void>;
+    // creates data in config file
+    abstract createConfigData(data: CredentialStatusConfigData): Promise<void>;
 
-  // retrieves data from config file
-  abstract readConfigData(): Promise<CredentialStatusConfigData>;
+    // retrieves data from config file
+    abstract readConfigData(): Promise<CredentialStatusConfigData>;
 
-  // updates data in config file
-  abstract updateConfigData(data: CredentialStatusConfigData): Promise<void>;
+    // updates data in config file
+    abstract updateConfigData(data: CredentialStatusConfigData): Promise<void>;
 
-  // creates data in log file
-  abstract createLogData(data: CredentialStatusLogData): Promise<void>;
+    // creates data in log file
+    abstract createLogData(data: CredentialStatusLogData): Promise<void>;
 
-  // retrieves data from log file
-  abstract readLogData(): Promise<CredentialStatusLogData>;
+    // retrieves data from log file
+    abstract readLogData(): Promise<CredentialStatusLogData>;
 
-  // updates data in log file
-  abstract updateLogData(data: CredentialStatusLogData): Promise<void>;
+    // updates data in log file
+    abstract updateLogData(data: CredentialStatusLogData): Promise<void>;
 
-  // creates data in status file
-  abstract createStatusData(data: VerifiableCredential): Promise<void>;
+    // creates data in status file
+    abstract createStatusData(data: VerifiableCredential): Promise<void>;
 
-  // retrieves data from status file
-  abstract readStatusData(): Promise<VerifiableCredential>;
+    // retrieves data from status file
+    abstract readStatusData(): Promise<VerifiableCredential>;
 
-  // updates data in status file
-  abstract updateStatusData(data: VerifiableCredential): Promise<void>;
+    // updates data in status file
+    abstract updateStatusData(data: VerifiableCredential): Promise<void>;
 }
 
 // composes StatusList2021Credential
 export async function composeStatusCredential({
-  issuerDid,
-  credentialId,
-  statusList,
-  statusPurpose = 'revocation'
+    issuerDid,
+    credentialId,
+    statusList,
+    statusPurpose = 'revocation'
 }: ComposeStatusCredentialOptions): Promise<any> {
-  // determine whether or not to create a new status list
-  if (!statusList) {
-    statusList = await createList({ length: CREDENTIAL_STATUS_LIST_SIZE });
-  }
+    // determine whether or not to create a new status list
+    if (!statusList) {
+        statusList = await createList({ length: CREDENTIAL_STATUS_LIST_SIZE });
+    }
 
-  // create status credential
-  const issuanceDate = getDateString();
-  let credential = await createCredential({
-    id: credentialId,
-    list: statusList,
-    statusPurpose
-  });
-  credential = {
-    ...credential,
-    issuer: issuerDid,
-    issuanceDate
-  };
+    // create status credential
+    const issuanceDate = getDateString();
+    let credential = await createCredential({
+        id: credentialId,
+        list: statusList,
+        statusPurpose
+    });
+    credential = {
+        ...credential,
+        issuer: issuerDid,
+        issuanceDate
+    };
 
-  return credential;
+    return credential;
 }

--- a/src/credential-status-manager-base.ts
+++ b/src/credential-status-manager-base.ts
@@ -186,7 +186,7 @@ export abstract class BaseCredentialStatusManager {
         id: statusListId,
         type: CREDENTIAL_STATUS_TYPE,
         statusPurpose,
-        statusListIndex,
+        statusListIndex: statusListIndex.toString(),
         statusListCredential
       };
 
@@ -220,7 +220,7 @@ export abstract class BaseCredentialStatusManager {
     // attach credential status
     const statusUrl = this.getCredentialStatusUrl();
     const statusListCredential = `${statusUrl}/${latestList}`;
-    const statusListIndex = credentialsIssued;
+    const statusListIndex = credentialsIssued.toString(); 
     const statusListId = `${statusListCredential}#${statusListIndex}`;
     const credentialStatus = {
       id: statusListId,

--- a/test/credential-status-manager-github.spec.ts
+++ b/test/credential-status-manager-github.spec.ts
@@ -8,195 +8,195 @@ import { VerifiableCredential } from '@digitalcredentials/vc-data-model';
 import * as OctokitClient from '@octokit/rest';
 import { createStatusManager } from '../src/index.js';
 import {
-  BaseCredentialStatusManager,
-  CredentialState,
-  CredentialStatusConfigData,
-  CredentialStatusLogData,
-  CredentialStatusLogEntry,
-  CredentialStatusManagerService
+    BaseCredentialStatusManager,
+    CredentialState,
+    CredentialStatusConfigData,
+    CredentialStatusLogData,
+    CredentialStatusLogEntry,
+    CredentialStatusManagerService
 } from '../src/credential-status-manager-base.js';
 import * as GithubStatus from '../src/credential-status-manager-github.js';
 import {
-  checkLocalCredentialStatus,
-  checkRemoteCredentialStatus,
-  checkStatusCredential,
-  didMethod,
-  didSeed,
-  metaRepoAccessToken,
-  metaRepoName,
-  ownerAccountName,
-  repoAccessToken,
-  repoName,
-  statusListId,
-  unsignedCredential1,
-  unsignedCredential2,
-  unsignedCredential3
+    checkLocalCredentialStatus,
+    checkRemoteCredentialStatus,
+    checkStatusCredential,
+    didMethod,
+    didSeed,
+    metaRepoAccessToken,
+    metaRepoName,
+    ownerAccountName,
+    repoAccessToken,
+    repoName,
+    statusListId,
+    unsignedCredential1,
+    unsignedCredential2,
+    unsignedCredential3
 } from './helpers.js';
 
 const sandbox = createSandbox();
 
 class MockGithubCredentialStatusManager extends GithubStatus.GithubCredentialStatusManager {
-  private statusCredential: VerifiableCredential;
-  private statusConfig: CredentialStatusConfigData;
-  private statusLog: CredentialStatusLogEntry[];
+    private statusCredential: VerifiableCredential;
+    private statusConfig: CredentialStatusConfigData;
+    private statusLog: CredentialStatusLogEntry[];
 
-  constructor(options: GithubStatus.GithubCredentialStatusManagerOptions) {
-    const {
-      ownerAccountName,
-      repoName,
-      metaRepoName,
-      repoAccessToken,
-      metaRepoAccessToken,
-      didMethod,
-      didSeed
-    } = options;
-    super({
-      ownerAccountName,
-      repoName,
-      metaRepoName,
-      repoAccessToken,
-      metaRepoAccessToken,
-      didMethod,
-      didSeed
-    });
-    this.statusCredential = {} as VerifiableCredential;
-    this.statusConfig = {} as CredentialStatusConfigData;
-    this.statusLog = [];
-  }
+    constructor(options: GithubStatus.GithubCredentialStatusManagerOptions) {
+        const {
+            ownerAccountName,
+            repoName,
+            metaRepoName,
+            repoAccessToken,
+            metaRepoAccessToken,
+            didMethod,
+            didSeed
+        } = options;
+        super({
+            ownerAccountName,
+            repoName,
+            metaRepoName,
+            repoAccessToken,
+            metaRepoAccessToken,
+            didMethod,
+            didSeed
+        });
+        this.statusCredential = {} as VerifiableCredential;
+        this.statusConfig = {} as CredentialStatusConfigData;
+        this.statusLog = [];
+    }
 
-  // generates new status list ID
-  generateStatusListId(): string {
-    return statusListId;
-  }
+    // generates new status list ID
+    generateStatusListId(): string {
+        return statusListId;
+    }
 
-  // deploys website to host credential status management resources
-  async deployCredentialStatusWebsite(): Promise<void> {}
+    // deploys website to host credential status management resources
+    async deployCredentialStatusWebsite(): Promise<void> { }
 
-  // checks if caller has authority to update status based on status repo access token
-  async hasStatusAuthority(repoAccessToken: string): Promise<boolean> { return true; }
+    // checks if caller has authority to update status based on status repo access token
+    async hasStatusAuthority(repoAccessToken: string): Promise<boolean> { return true; }
 
-  // checks if status repos exist
-  async statusReposExist(): Promise<boolean> { return true; }
+    // checks if status repos exist
+    async statusReposExist(): Promise<boolean> { return true; }
 
-  // retrieves data from status repo
-  async readRepoData(): Promise<any> {
-    throw new Error();
-  }
+    // retrieves data from status repo
+    async readRepoData(): Promise<any> {
+        throw new Error();
+    }
 
-  // retrieves data from status metadata repo
-  async readMetaRepoData(): Promise<any> {
-    throw new Error();
-  }
+    // retrieves data from status metadata repo
+    async readMetaRepoData(): Promise<any> {
+        throw new Error();
+    }
 
-  // creates data in config file
-  async createConfigData(data: CredentialStatusConfigData): Promise<void> {
-    this.statusConfig = data;
-  }
+    // creates data in config file
+    async createConfigData(data: CredentialStatusConfigData): Promise<void> {
+        this.statusConfig = data;
+    }
 
-  // retrieves data from config file
-  async readConfigData(): Promise<CredentialStatusConfigData> {
-    return this.statusConfig;
-  }
+    // retrieves data from config file
+    async readConfigData(): Promise<CredentialStatusConfigData> {
+        return this.statusConfig;
+    }
 
-  // updates data in config file
-  async updateConfigData(data: CredentialStatusConfigData): Promise<void> {
-    this.statusConfig = data;
-  }
+    // updates data in config file
+    async updateConfigData(data: CredentialStatusConfigData): Promise<void> {
+        this.statusConfig = data;
+    }
 
-  // creates data in log file
-  async createLogData(data: CredentialStatusLogData): Promise<void> {
-    this.statusLog = data;
-  }
+    // creates data in log file
+    async createLogData(data: CredentialStatusLogData): Promise<void> {
+        this.statusLog = data;
+    }
 
-  // retrieves data from log file
-  async readLogData(): Promise<CredentialStatusLogData> {
-    return this.statusLog;
-  }
+    // retrieves data from log file
+    async readLogData(): Promise<CredentialStatusLogData> {
+        return this.statusLog;
+    }
 
-  // updates data in log file
-  async updateLogData(data: CredentialStatusLogData): Promise<void> {
-    this.statusLog = data;
-  }
+    // updates data in log file
+    async updateLogData(data: CredentialStatusLogData): Promise<void> {
+        this.statusLog = data;
+    }
 
-  // creates data in status file
-  async createStatusData(data: VerifiableCredential): Promise<void> {
-    this.statusCredential = data;
-  }
+    // creates data in status file
+    async createStatusData(data: VerifiableCredential): Promise<void> {
+        this.statusCredential = data;
+    }
 
-  // retrieves data from status file
-  async readStatusData(): Promise<VerifiableCredential> {
-    return this.statusCredential;
-  }
+    // retrieves data from status file
+    async readStatusData(): Promise<VerifiableCredential> {
+        return this.statusCredential;
+    }
 
-  // updates data in status file
-  async updateStatusData(data: VerifiableCredential): Promise<void> {
-    this.statusCredential = data;
-  }
+    // updates data in status file
+    async updateStatusData(data: VerifiableCredential): Promise<void> {
+        this.statusCredential = data;
+    }
 }
 
 describe('GitHub Credential Status Manager', () => {
-  const service = 'github' as CredentialStatusManagerService;
-  let statusManager: GithubStatus.GithubCredentialStatusManager;
-  sandbox.stub(OctokitClient.Octokit.prototype, 'constructor').returns(null);
-  sandbox.stub(GithubStatus, 'GithubCredentialStatusManager').value(MockGithubCredentialStatusManager);
+    const service = 'github' as CredentialStatusManagerService;
+    let statusManager: GithubStatus.GithubCredentialStatusManager;
+    sandbox.stub(OctokitClient.Octokit.prototype, 'constructor').returns(null);
+    sandbox.stub(GithubStatus, 'GithubCredentialStatusManager').value(MockGithubCredentialStatusManager);
 
-  beforeEach(async () => {
-    statusManager = await createStatusManager({
-      service,
-      ownerAccountName,
-      repoName,
-      metaRepoName,
-      repoAccessToken,
-      metaRepoAccessToken,
-      didMethod,
-      didSeed
-    }) as GithubStatus.GithubCredentialStatusManager;
-  });
+    beforeEach(async () => {
+        statusManager = await createStatusManager({
+            service,
+            ownerAccountName,
+            repoName,
+            metaRepoName,
+            repoAccessToken,
+            metaRepoAccessToken,
+            didMethod,
+            didSeed
+        }) as GithubStatus.GithubCredentialStatusManager;
+    });
 
-  it('tests output of createStatusManager', async () => {
-    expect(statusManager).to.be.instanceof(BaseCredentialStatusManager);
-    expect(statusManager).to.be.instanceof(GithubStatus.GithubCredentialStatusManager);
-  });
+    it('tests output of createStatusManager', async () => {
+        expect(statusManager).to.be.instanceof(BaseCredentialStatusManager);
+        expect(statusManager).to.be.instanceof(GithubStatus.GithubCredentialStatusManager);
+    });
 
-  it('tests allocateStatus', async () => {
-    // allocate and check status for first credential
-    const credentialWithStatus1 = await statusManager.allocateStatus(unsignedCredential1) as any;
-    checkLocalCredentialStatus(credentialWithStatus1, 1, service);
+    it('tests allocateStatus', async () => {
+        // allocate and check status for first credential
+        const credentialWithStatus1 = await statusManager.allocateStatus(unsignedCredential1) as any;
+        checkLocalCredentialStatus(credentialWithStatus1, '1', service);
 
-    // allocate and check status for second credential
-    const credentialWithStatus2 = await statusManager.allocateStatus(unsignedCredential2) as any;
-    checkLocalCredentialStatus(credentialWithStatus2, 2, service);
+        // allocate and check status for second credential
+        const credentialWithStatus2 = await statusManager.allocateStatus(unsignedCredential2) as any;
+        checkLocalCredentialStatus(credentialWithStatus2, '2', service);
 
-    // allocate and check status for third credential
-    const credentialWithStatus3 = await statusManager.allocateStatus(unsignedCredential3) as any;
-    checkLocalCredentialStatus(credentialWithStatus3, 3, service);
+        // allocate and check status for third credential
+        const credentialWithStatus3 = await statusManager.allocateStatus(unsignedCredential3) as any;
+        checkLocalCredentialStatus(credentialWithStatus3, '3', service);
 
-    // attempt to allocate and check status for existing credential
-    const credentialWithStatus2Copy = await statusManager.allocateStatus(unsignedCredential2) as any;
-    checkLocalCredentialStatus(credentialWithStatus2Copy, 2, service);
+        // attempt to allocate and check status for existing credential
+        const credentialWithStatus2Copy = await statusManager.allocateStatus(unsignedCredential2) as any;
+        checkLocalCredentialStatus(credentialWithStatus2Copy, '2', service);
 
-    // check if status repos are properly configured
-    expect(await statusManager.statusReposProperlyConfigured()).to.be.true;
-  });
+        // check if status repos are properly configured
+        expect(await statusManager.statusReposProperlyConfigured()).to.be.true;
+    });
 
-  it('tests updateStatus and checkStatus', async () => {
-    // allocate status for credential
-    const credentialWithStatus = await statusManager.allocateStatus(unsignedCredential1) as any;
+    it('tests updateStatus and checkStatus', async () => {
+        // allocate status for credential
+        const credentialWithStatus = await statusManager.allocateStatus(unsignedCredential1) as any;
 
-    // update status of credential
-    const statusCredential = await statusManager.updateStatus({
-      credentialId: credentialWithStatus.id,
-      credentialStatus: 'revoked' as CredentialState
-    }) as any;
+        // update status of credential
+        const statusCredential = await statusManager.updateStatus({
+            credentialId: credentialWithStatus.id,
+            credentialStatus: 'revoked' as CredentialState
+        }) as any;
 
-    // check status credential
-    checkStatusCredential(statusCredential, service);
+        // check status credential
+        checkStatusCredential(statusCredential, service);
 
-    // check status of credential
-    const credentialStatus = await statusManager.checkStatus(credentialWithStatus.id);
-    checkRemoteCredentialStatus(credentialStatus, credentialWithStatus.id, 1);
+        // check status of credential
+        const credentialStatus = await statusManager.checkStatus(credentialWithStatus.id);
+        checkRemoteCredentialStatus(credentialStatus, credentialWithStatus.id, '1');
 
-    // check if status repos are properly configured
-    expect(await statusManager.statusReposProperlyConfigured()).to.be.true;
-  });
+        // check if status repos are properly configured
+        expect(await statusManager.statusReposProperlyConfigured()).to.be.true;
+    });
 });

--- a/test/credential-status-manager-gitlab.spec.ts
+++ b/test/credential-status-manager-gitlab.spec.ts
@@ -8,203 +8,203 @@ import { VerifiableCredential } from '@digitalcredentials/vc-data-model';
 import * as AxiosClient from 'axios';
 import { createStatusManager } from '../src/index.js';
 import {
-  BaseCredentialStatusManager,
-  CredentialState,
-  CredentialStatusConfigData,
-  CredentialStatusLogData,
-  CredentialStatusLogEntry,
-  CredentialStatusManagerService
+    BaseCredentialStatusManager,
+    CredentialState,
+    CredentialStatusConfigData,
+    CredentialStatusLogData,
+    CredentialStatusLogEntry,
+    CredentialStatusManagerService
 } from '../src/credential-status-manager-base.js';
 import * as GitlabStatus from '../src/credential-status-manager-gitlab.js';
 import {
-  checkLocalCredentialStatus,
-  checkRemoteCredentialStatus,
-  checkStatusCredential,
-  didMethod,
-  didSeed,
-  metaRepoAccessToken,
-  metaRepoId,
-  metaRepoName,
-  ownerAccountName,
-  repoAccessToken,
-  repoId,
-  repoName,
-  statusListId,
-  unsignedCredential1,
-  unsignedCredential2,
-  unsignedCredential3
+    checkLocalCredentialStatus,
+    checkRemoteCredentialStatus,
+    checkStatusCredential,
+    didMethod,
+    didSeed,
+    metaRepoAccessToken,
+    metaRepoId,
+    metaRepoName,
+    ownerAccountName,
+    repoAccessToken,
+    repoId,
+    repoName,
+    statusListId,
+    unsignedCredential1,
+    unsignedCredential2,
+    unsignedCredential3
 } from './helpers.js';
 
 const sandbox = createSandbox();
 
 class MockGitlabCredentialStatusManager extends GitlabStatus.GitlabCredentialStatusManager {
-  private statusCredential: VerifiableCredential;
-  private statusConfig: CredentialStatusConfigData;
-  private statusLog: CredentialStatusLogEntry[];
+    private statusCredential: VerifiableCredential;
+    private statusConfig: CredentialStatusConfigData;
+    private statusLog: CredentialStatusLogEntry[];
 
-  constructor(options: GitlabStatus.GitlabCredentialStatusManagerOptions) {
-    const {
-      ownerAccountName,
-      repoName,
-      repoId,
-      metaRepoName,
-      metaRepoId,
-      repoAccessToken,
-      metaRepoAccessToken,
-      didMethod,
-      didSeed
-    } = options;
-    super({
-      ownerAccountName,
-      repoName,
-      repoId,
-      metaRepoName,
-      metaRepoId,
-      repoAccessToken,
-      metaRepoAccessToken,
-      didMethod,
-      didSeed
-    });
-    this.statusCredential = {} as VerifiableCredential;
-    this.statusConfig = {} as CredentialStatusConfigData;
-    this.statusLog = [];
-  }
+    constructor(options: GitlabStatus.GitlabCredentialStatusManagerOptions) {
+        const {
+            ownerAccountName,
+            repoName,
+            repoId,
+            metaRepoName,
+            metaRepoId,
+            repoAccessToken,
+            metaRepoAccessToken,
+            didMethod,
+            didSeed
+        } = options;
+        super({
+            ownerAccountName,
+            repoName,
+            repoId,
+            metaRepoName,
+            metaRepoId,
+            repoAccessToken,
+            metaRepoAccessToken,
+            didMethod,
+            didSeed
+        });
+        this.statusCredential = {} as VerifiableCredential;
+        this.statusConfig = {} as CredentialStatusConfigData;
+        this.statusLog = [];
+    }
 
-  // generates new status list ID
-  generateStatusListId(): string {
-    return statusListId;
-  }
+    // generates new status list ID
+    generateStatusListId(): string {
+        return statusListId;
+    }
 
-  // deploys website to host credential status management resources
-  async deployCredentialStatusWebsite(): Promise<void> {}
+    // deploys website to host credential status management resources
+    async deployCredentialStatusWebsite(): Promise<void> { }
 
-  // checks if caller has authority to update status based on status repo access token
-  async hasStatusAuthority(repoAccessToken: string): Promise<boolean> { return true; }
+    // checks if caller has authority to update status based on status repo access token
+    async hasStatusAuthority(repoAccessToken: string): Promise<boolean> { return true; }
 
-  // checks if status repos exist
-  async statusReposExist(): Promise<boolean> { return true; }
+    // checks if status repos exist
+    async statusReposExist(): Promise<boolean> { return true; }
 
-  // retrieves data from status repo
-  async readRepoData(): Promise<any> {
-    throw new Error();
-  }
+    // retrieves data from status repo
+    async readRepoData(): Promise<any> {
+        throw new Error();
+    }
 
-  // retrieves data from status metadata repo
-  async readMetaRepoData(): Promise<any> {
-    throw new Error();
-  }
+    // retrieves data from status metadata repo
+    async readMetaRepoData(): Promise<any> {
+        throw new Error();
+    }
 
-  // creates data in config file
-  async createConfigData(data: CredentialStatusConfigData): Promise<void> {
-    this.statusConfig = data;
-  }
+    // creates data in config file
+    async createConfigData(data: CredentialStatusConfigData): Promise<void> {
+        this.statusConfig = data;
+    }
 
-  // retrieves data from config file
-  async readConfigData(): Promise<CredentialStatusConfigData> {
-    return this.statusConfig;
-  }
+    // retrieves data from config file
+    async readConfigData(): Promise<CredentialStatusConfigData> {
+        return this.statusConfig;
+    }
 
-  // updates data in config file
-  async updateConfigData(data: CredentialStatusConfigData): Promise<void> {
-    this.statusConfig = data;
-  }
+    // updates data in config file
+    async updateConfigData(data: CredentialStatusConfigData): Promise<void> {
+        this.statusConfig = data;
+    }
 
-  // creates data in log file
-  async createLogData(data: CredentialStatusLogData): Promise<void> {
-    this.statusLog = data;
-  }
+    // creates data in log file
+    async createLogData(data: CredentialStatusLogData): Promise<void> {
+        this.statusLog = data;
+    }
 
-  // retrieves data from log file
-  async readLogData(): Promise<CredentialStatusLogData> {
-    return this.statusLog;
-  }
+    // retrieves data from log file
+    async readLogData(): Promise<CredentialStatusLogData> {
+        return this.statusLog;
+    }
 
-  // updates data in log file
-  async updateLogData(data: CredentialStatusLogData): Promise<void> {
-    this.statusLog = data;
-  }
+    // updates data in log file
+    async updateLogData(data: CredentialStatusLogData): Promise<void> {
+        this.statusLog = data;
+    }
 
-  // creates data in status file
-  async createStatusData(data: VerifiableCredential): Promise<void> {
-    this.statusCredential = data;
-  }
+    // creates data in status file
+    async createStatusData(data: VerifiableCredential): Promise<void> {
+        this.statusCredential = data;
+    }
 
-  // retrieves data from status file
-  async readStatusData(): Promise<VerifiableCredential> {
-    return this.statusCredential;
-  }
+    // retrieves data from status file
+    async readStatusData(): Promise<VerifiableCredential> {
+        return this.statusCredential;
+    }
 
-  // updates data in status file
-  async updateStatusData(data: VerifiableCredential): Promise<void> {
-    this.statusCredential = data;
-  }
+    // updates data in status file
+    async updateStatusData(data: VerifiableCredential): Promise<void> {
+        this.statusCredential = data;
+    }
 }
 
 describe('GitLab Credential Status Manager', () => {
-  const service = 'gitlab' as CredentialStatusManagerService;
-  let statusManager: GitlabStatus.GitlabCredentialStatusManager;
-  sandbox.stub(AxiosClient.default, 'create').returnsThis();
-  sandbox.stub(GitlabStatus, 'GitlabCredentialStatusManager').value(MockGitlabCredentialStatusManager);
+    const service = 'gitlab' as CredentialStatusManagerService;
+    let statusManager: GitlabStatus.GitlabCredentialStatusManager;
+    sandbox.stub(AxiosClient.default, 'create').returnsThis();
+    sandbox.stub(GitlabStatus, 'GitlabCredentialStatusManager').value(MockGitlabCredentialStatusManager);
 
-  beforeEach(async () => {
-    statusManager = await createStatusManager({
-      service,
-      ownerAccountName,
-      repoName,
-      repoId,
-      metaRepoName,
-      metaRepoId,
-      repoAccessToken,
-      metaRepoAccessToken,
-      didMethod,
-      didSeed
-    }) as GitlabStatus.GitlabCredentialStatusManager;
-  });
+    beforeEach(async () => {
+        statusManager = await createStatusManager({
+            service,
+            ownerAccountName,
+            repoName,
+            repoId,
+            metaRepoName,
+            metaRepoId,
+            repoAccessToken,
+            metaRepoAccessToken,
+            didMethod,
+            didSeed
+        }) as GitlabStatus.GitlabCredentialStatusManager;
+    });
 
-  it('tests output of createStatusManager', async () => {
-    expect(statusManager).to.be.instanceof(BaseCredentialStatusManager);
-    expect(statusManager).to.be.instanceof(GitlabStatus.GitlabCredentialStatusManager);
-  });
+    it('tests output of createStatusManager', async () => {
+        expect(statusManager).to.be.instanceof(BaseCredentialStatusManager);
+        expect(statusManager).to.be.instanceof(GitlabStatus.GitlabCredentialStatusManager);
+    });
 
-  it('tests allocateStatus', async () => {
-    // allocate and check status for first credential
-    const credentialWithStatus1 = await statusManager.allocateStatus(unsignedCredential1) as any;
-    checkLocalCredentialStatus(credentialWithStatus1, 1, service);
+    it('tests allocateStatus', async () => {
+        // allocate and check status for first credential
+        const credentialWithStatus1 = await statusManager.allocateStatus(unsignedCredential1) as any;
+        checkLocalCredentialStatus(credentialWithStatus1, '1', service);
 
-    // allocate and check status for second credential
-    const credentialWithStatus2 = await statusManager.allocateStatus(unsignedCredential2) as any;
-    checkLocalCredentialStatus(credentialWithStatus2, 2, service);
+        // allocate and check status for second credential
+        const credentialWithStatus2 = await statusManager.allocateStatus(unsignedCredential2) as any;
+        checkLocalCredentialStatus(credentialWithStatus2, '2', service);
 
-    // allocate and check status for third credential
-    const credentialWithStatus3 = await statusManager.allocateStatus(unsignedCredential3) as any;
-    checkLocalCredentialStatus(credentialWithStatus3, 3, service);
+        // allocate and check status for third credential
+        const credentialWithStatus3 = await statusManager.allocateStatus(unsignedCredential3) as any;
+        checkLocalCredentialStatus(credentialWithStatus3, '3', service);
 
-    // attempt to allocate and check status for existing credential
-    const credentialWithStatus2Copy = await statusManager.allocateStatus(unsignedCredential2) as any;
-    checkLocalCredentialStatus(credentialWithStatus2Copy, 2, service);
+        // attempt to allocate and check status for existing credential
+        const credentialWithStatus2Copy = await statusManager.allocateStatus(unsignedCredential2) as any;
+        checkLocalCredentialStatus(credentialWithStatus2Copy, '2', service);
 
-    // check if status repos are properly configured
-    expect(await statusManager.statusReposProperlyConfigured()).to.be.true;
-  });
+        // check if status repos are properly configured
+        expect(await statusManager.statusReposProperlyConfigured()).to.be.true;
+    });
 
-  it('tests updateStatus and checkStatus', async () => {
-    // allocate status for credential
-    const credentialWithStatus = await statusManager.allocateStatus(unsignedCredential1) as any;
+    it('tests updateStatus and checkStatus', async () => {
+        // allocate status for credential
+        const credentialWithStatus = await statusManager.allocateStatus(unsignedCredential1) as any;
 
-    // update status of credential
-    const statusCredential = await statusManager.updateStatus({
-      credentialId: credentialWithStatus.id,
-      credentialStatus: 'revoked' as CredentialState
-    }) as any;
+        // update status of credential
+        const statusCredential = await statusManager.updateStatus({
+            credentialId: credentialWithStatus.id,
+            credentialStatus: 'revoked' as CredentialState
+        }) as any;
 
-    // check status credential
-    checkStatusCredential(statusCredential, service);
+        // check status credential
+        checkStatusCredential(statusCredential, service);
 
-    // check status of credential
-    const credentialStatus = await statusManager.checkStatus(credentialWithStatus.id);
-    checkRemoteCredentialStatus(credentialStatus, credentialWithStatus.id, 1);
+        // check status of credential
+        const credentialStatus = await statusManager.checkStatus(credentialWithStatus.id);
+        checkRemoteCredentialStatus(credentialStatus, credentialWithStatus.id, '1');
 
-    // check if status repos are properly configured
-    expect(await statusManager.statusReposProperlyConfigured()).to.be.true;
-  });
+        // check if status repos are properly configured
+        expect(await statusManager.statusReposProperlyConfigured()).to.be.true;
+    });
 });

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -14,33 +14,33 @@ const issuerDid = `did:key:${issuerKey}`;
 const verificationMethod = `${issuerDid}#${issuerKey}`;
 
 const unsignedCredential = {
-  '@context': [
-    'https://www.w3.org/2018/credentials/v1',
-    'https://w3id.org/security/suites/ed25519-2020/v1'
-  ],
-  type: [
-    'VerifiableCredential'
-  ],
-  issuer: issuerDid,
-  issuanceDate: '2020-03-10T04:24:12.164Z',
-  credentialSubject: {
-    id: credentialSubject
-  }
+    '@context': [
+        'https://www.w3.org/2018/credentials/v1',
+        'https://w3id.org/security/suites/ed25519-2020/v1'
+    ],
+    type: [
+        'VerifiableCredential'
+    ],
+    issuer: issuerDid,
+    issuanceDate: '2020-03-10T04:24:12.164Z',
+    credentialSubject: {
+        id: credentialSubject
+    }
 };
 
 export const unsignedCredential1 = {
-  ...unsignedCredential,
-  id: credentialId1
+    ...unsignedCredential,
+    id: credentialId1
 };
 
 export const unsignedCredential2 = {
-  ...unsignedCredential,
-  id: credentialId2
+    ...unsignedCredential,
+    id: credentialId2
 };
 
 export const unsignedCredential3 = {
-  ...unsignedCredential,
-  id: credentialId3
+    ...unsignedCredential,
+    id: credentialId3
 };
 
 export const ownerAccountName = 'university-xyz';
@@ -55,77 +55,77 @@ export const didSeed = 'DsnrHBHFQP0ab59dQELh3uEwy7i5ArcOTwxkwRO2hM87CBRGWBEChPO7
 export const statusListId = 'V27UAUYPNR';
 
 export function checkLocalCredentialStatus(
-  credentialWithStatus: any,
-  statusListIndex: number,
-  service: CredentialStatusManagerService
+    credentialWithStatus: any,
+    statusListIndex: string,
+    service: CredentialStatusManagerService
 ) {
-  let statusCredentialId;
-  switch (service) {
-    case CredentialStatusManagerService.Github:
-      statusCredentialId = `https://${ownerAccountName}.github.io/${repoName}/${statusListId}`;
-      break;
-    case CredentialStatusManagerService.Gitlab:
-      statusCredentialId = `https://${ownerAccountName}.gitlab.io/${repoName}/${statusListId}`;
-      break;
-  }
-  expect(credentialWithStatus).to.have.property('credentialStatus');
-  expect(credentialWithStatus.credentialStatus).to.have.property('id');
-  expect(credentialWithStatus.credentialStatus).to.have.property('type');
-  expect(credentialWithStatus.credentialStatus).to.have.property('statusPurpose');
-  expect(credentialWithStatus.credentialStatus).to.have.property('statusListIndex');
-  expect(credentialWithStatus.credentialStatus).to.have.property('statusListCredential');
-  expect(credentialWithStatus.credentialStatus.type).to.equal('StatusList2021Entry');
-  expect(credentialWithStatus.credentialStatus.statusPurpose).to.equal('revocation');
-  expect(credentialWithStatus.credentialStatus.statusListIndex).to.equal(statusListIndex);
-  expect(credentialWithStatus.credentialStatus.id.startsWith(statusCredentialId)).to.be.true;
-  expect(credentialWithStatus.credentialStatus.statusListCredential.startsWith(statusCredentialId)).to.be.true;
+    let statusCredentialId;
+    switch (service) {
+        case CredentialStatusManagerService.Github:
+            statusCredentialId = `https://${ownerAccountName}.github.io/${repoName}/${statusListId}`;
+            break;
+        case CredentialStatusManagerService.Gitlab:
+            statusCredentialId = `https://${ownerAccountName}.gitlab.io/${repoName}/${statusListId}`;
+            break;
+    }
+    expect(credentialWithStatus).to.have.property('credentialStatus');
+    expect(credentialWithStatus.credentialStatus).to.have.property('id');
+    expect(credentialWithStatus.credentialStatus).to.have.property('type');
+    expect(credentialWithStatus.credentialStatus).to.have.property('statusPurpose');
+    expect(credentialWithStatus.credentialStatus).to.have.property('statusListIndex');
+    expect(credentialWithStatus.credentialStatus).to.have.property('statusListCredential');
+    expect(credentialWithStatus.credentialStatus.type).to.equal('StatusList2021Entry');
+    expect(credentialWithStatus.credentialStatus.statusPurpose).to.equal('revocation');
+    expect(credentialWithStatus.credentialStatus.statusListIndex).to.equal(statusListIndex);
+    expect(credentialWithStatus.credentialStatus.id.startsWith(statusCredentialId)).to.be.true;
+    expect(credentialWithStatus.credentialStatus.statusListCredential.startsWith(statusCredentialId)).to.be.true;
 }
 
 export function checkRemoteCredentialStatus(
-  credentialStatus: any,
-  credentialId: string,
-  statusListIndex: number
+    credentialStatus: any,
+    credentialId: string,
+    statusListIndex: string
 ) {
-  expect(credentialStatus).to.have.property('timestamp');
-  expect(credentialStatus).to.have.property('credentialId');
-  expect(credentialStatus).to.have.property('credentialIssuer');
-  expect(credentialStatus).to.have.property('credentialSubject');
-  expect(credentialStatus).to.have.property('credentialState');
-  expect(credentialStatus).to.have.property('verificationMethod');
-  expect(credentialStatus).to.have.property('statusListId');
-  expect(credentialStatus).to.have.property('statusListIndex');
-  expect(credentialStatus.credentialId).to.equal(credentialId);
-  expect(credentialStatus.credentialIssuer).to.equal(issuerDid);
-  expect(credentialStatus.credentialSubject).to.equal(credentialSubject);
-  expect(credentialStatus.credentialState).to.equal('revoked');
-  expect(credentialStatus.verificationMethod).to.equal(verificationMethod);
-  expect(credentialStatus.statusListId).to.equal(statusListId);
-  expect(credentialStatus.statusListIndex).to.equal(statusListIndex);
+    expect(credentialStatus).to.have.property('timestamp');
+    expect(credentialStatus).to.have.property('credentialId');
+    expect(credentialStatus).to.have.property('credentialIssuer');
+    expect(credentialStatus).to.have.property('credentialSubject');
+    expect(credentialStatus).to.have.property('credentialState');
+    expect(credentialStatus).to.have.property('verificationMethod');
+    expect(credentialStatus).to.have.property('statusListId');
+    expect(credentialStatus).to.have.property('statusListIndex');
+    expect(credentialStatus.credentialId).to.equal(credentialId);
+    expect(credentialStatus.credentialIssuer).to.equal(issuerDid);
+    expect(credentialStatus.credentialSubject).to.equal(credentialSubject);
+    expect(credentialStatus.credentialState).to.equal('revoked');
+    expect(credentialStatus.verificationMethod).to.equal(verificationMethod);
+    expect(credentialStatus.statusListId).to.equal(statusListId);
+    expect(credentialStatus.statusListIndex).to.equal(statusListIndex);
 }
 
 export function checkStatusCredential(
-  statusCredential: any,
-  service: CredentialStatusManagerService
+    statusCredential: any,
+    service: CredentialStatusManagerService
 ) {
-  let statusCredentialId;
-  switch (service) {
-    case CredentialStatusManagerService.Github:
-      statusCredentialId = `https://${ownerAccountName}.github.io/${repoName}/${statusListId}`;
-      break;
-    case CredentialStatusManagerService.Gitlab:
-      statusCredentialId = `https://${ownerAccountName}.gitlab.io/${repoName}/${statusListId}`;
-      break;
-  }
-  expect(statusCredential).to.have.property('id');
-  expect(statusCredential).to.have.property('type');
-  expect(statusCredential).to.have.property('credentialSubject');
-  expect(statusCredential.credentialSubject).to.have.property('id');
-  expect(statusCredential.credentialSubject).to.have.property('type');
-  expect(statusCredential.credentialSubject).to.have.property('encodedList');
-  expect(statusCredential.credentialSubject).to.have.property('statusPurpose');
-  expect(statusCredential.id).to.equal(statusCredentialId);
-  expect(statusCredential.type).to.include('StatusList2021Credential');
-  expect(statusCredential.credentialSubject.id.startsWith(statusCredentialId)).to.be.true;
-  expect(statusCredential.credentialSubject.type).to.equal('StatusList2021');
-  expect(statusCredential.credentialSubject.statusPurpose).to.equal('revocation');
+    let statusCredentialId;
+    switch (service) {
+        case CredentialStatusManagerService.Github:
+            statusCredentialId = `https://${ownerAccountName}.github.io/${repoName}/${statusListId}`;
+            break;
+        case CredentialStatusManagerService.Gitlab:
+            statusCredentialId = `https://${ownerAccountName}.gitlab.io/${repoName}/${statusListId}`;
+            break;
+    }
+    expect(statusCredential).to.have.property('id');
+    expect(statusCredential).to.have.property('type');
+    expect(statusCredential).to.have.property('credentialSubject');
+    expect(statusCredential.credentialSubject).to.have.property('id');
+    expect(statusCredential.credentialSubject).to.have.property('type');
+    expect(statusCredential.credentialSubject).to.have.property('encodedList');
+    expect(statusCredential.credentialSubject).to.have.property('statusPurpose');
+    expect(statusCredential.id).to.equal(statusCredentialId);
+    expect(statusCredential.type).to.include('StatusList2021Credential');
+    expect(statusCredential.credentialSubject.id.startsWith(statusCredentialId)).to.be.true;
+    expect(statusCredential.credentialSubject.type).to.equal('StatusList2021');
+    expect(statusCredential.credentialSubject.statusPurpose).to.equal('revocation');
 }


### PR DESCRIPTION
Technically, according to the spec, the status list index must be expressed as a string! (https://www.w3.org/TR/vc-status-list/#statuslist2021entry:~:text=The%20statusListIndex%20property%20MUST%20be%20an%20arbitrary%20size%20integer%20greater%20than%20or%20equal%20to%200%2C%20expressed%20as%20a%20string) This PR causes that to happen.

Side note: I only did this because currently, Spruce's Didkit library will fail to verify credentials due to the index not being a string! 
![image](https://github.com/digitalcredentials/credential-status-manager-git/assets/39720479/59d7b4cd-0b85-4ba5-8356-760a376d4b7c)
