### PR TITLE
checks client's authority to manage status repos during initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # credential-status-manager-git Changelog
 
-## 2.0.0 - 2023-XX-23
+## 2.0.0 - 2023-XX-24
 
 ### Added
 
 - Add fault recovery mechanism.
+- Use string for status list index.
+- Add custom error classes to improve error handling.
 
 ## 1.0.0 - 2023-06-23
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ console.log(credentialWithStatus);
     id: 'https://university-xyz.github.io/credential-status/V27UAUYPNR#1',
     type: 'StatusList2021Entry',
     statusPurpose: 'revocation',
-    statusListIndex: 1,
+    statusListIndex: '1',
     statusListCredential: 'https://university-xyz.github.io/credential-status/V27UAUYPNR'
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "prettier": "prettier src --write",
     "rebuild": "npm run clear && npm run build",
     "test": "npm run lint && npm run test-node",
-    "test-karma": "node pre-test.js; npm run build-test && karma start karma.conf.js && rm -rf dist/test; node post-test.js",
-    "test-node": "node pre-test.js; npm run build-test && mocha dist/test/*.spec.js && rm -rf dist/test; node post-test.js"
+    "test-karma": "npm run build-test && karma start karma.conf.js && rm -rf dist/test",
+    "test-node": "npm run build-test && mocha dist/test/*.spec.js && rm -rf dist/test"
   },
   "files": [
     "dist",

--- a/post-test.js
+++ b/post-test.js
@@ -16,11 +16,11 @@ const updateTsconfig = async () => {
   fs.writeFileSync(tsconfigFilePath, JSON.stringify(tsconfigJson, null, 2));
 };
 
-// combine pre-test subscripts
+// combine post-test subscripts
 const runPostTest = async () => {
   await updatePackageJson();
   updateTsconfig();
 };
 
-// run pre-test subscripts
+// run post-test subscripts
 runPostTest();

--- a/src/credential-status-manager-base.ts
+++ b/src/credential-status-manager-base.ts
@@ -535,7 +535,7 @@ export abstract class BaseCredentialStatusManager {
   async deployCredentialStatusWebsite(): Promise<void> {};
 
   // checks if caller has authority to update status based on status repo access token
-  abstract hasStatusAuthority(repoAccessToken: string): Promise<boolean>;
+  abstract hasStatusAuthority(repoAccessToken: string, metaRepoAccessToken?: string): Promise<boolean>;
 
   // checks if status repos exist
   abstract statusReposExist(): Promise<boolean>;

--- a/src/credential-status-manager-base.ts
+++ b/src/credential-status-manager-base.ts
@@ -206,7 +206,7 @@ export abstract class BaseCredentialStatusManager {
         id: credentialStatusId,
         type: CREDENTIAL_STATUS_TYPE,
         statusPurpose,
-        statusListIndex: credentialStatusIndex,
+        statusListIndex: credentialStatusIndex.toString(),
         statusListCredential: statusCredentialUrl
       };
 
@@ -243,7 +243,7 @@ export abstract class BaseCredentialStatusManager {
       id: credentialStatusId,
       type: CREDENTIAL_STATUS_TYPE,
       statusPurpose,
-      statusListIndex: credentialStatusIndex,
+      statusListIndex: credentialStatusIndex.toString(),
       statusListCredential: statusCredentialUrl
     };
 
@@ -331,7 +331,7 @@ export abstract class BaseCredentialStatusManager {
     // extract relevant data from credential status
     const {
       statusListCredential: statusCredentialUrl,
-      statusListIndex: credentialStatusIndex
+      statusListIndex
     } = credentialWithStatus.credentialStatus;
 
     // retrieve status credential ID from status credential URL
@@ -346,7 +346,7 @@ export abstract class BaseCredentialStatusManager {
       credentialState: CredentialState.Active,
       verificationMethod,
       statusCredentialId,
-      credentialStatusIndex
+      credentialStatusIndex: parseInt(statusListIndex)
     };
     eventLog.push(statusLogEntry);
 

--- a/src/credential-status-manager-github.ts
+++ b/src/credential-status-manager-github.ts
@@ -123,10 +123,9 @@ export class GithubCredentialStatusManager extends BaseCredentialStatusManager {
   // checks if caller has authority to update status based on status repo access token
   async hasStatusAuthority(repoAccessToken: string, metaRepoAccessToken?: string): Promise<boolean> {
     this.resetClientAuthorization(repoAccessToken, metaRepoAccessToken);
+
     let hasRepoAccess: boolean;
     let hasRepoScope: boolean;
-    let hasMetaRepoAccess: boolean;
-    let hasMetaRepoScope: boolean;
     try {
       const repoResponse = await this.repoClient.repos.get({
         owner: this.ownerAccountName,
@@ -141,6 +140,9 @@ export class GithubCredentialStatusManager extends BaseCredentialStatusManager {
       hasRepoAccess = false;
       hasRepoScope = false;
     }
+
+    let hasMetaRepoAccess: boolean;
+    let hasMetaRepoScope: boolean;
     try {
       const metaRepoResponse = await this.metaRepoClient.repos.get({
         owner: this.ownerAccountName,
@@ -155,6 +157,7 @@ export class GithubCredentialStatusManager extends BaseCredentialStatusManager {
       hasMetaRepoAccess = false;
       hasMetaRepoScope = false;
     }
+
     return hasRepoAccess && hasRepoScope && hasMetaRepoAccess && hasMetaRepoScope;
   }
 

--- a/src/credential-status-manager-gitlab.ts
+++ b/src/credential-status-manager-gitlab.ts
@@ -13,6 +13,7 @@ import {
   CredentialStatusConfigData,
   CredentialStatusSnapshotData
 } from './credential-status-manager-base.js';
+import { BadRequestError } from './errors.js';
 import {
   DidMethod,
   decodeSystemData,
@@ -64,30 +65,30 @@ const CREDENTIAL_STATUS_WEBSITE_FILE_PATHS = [
   CREDENTIAL_STATUS_WEBSITE_GEMFILE_PATH
 ];
 
-// Type definition for GitlabCredentialStatusManager constructor method input
-export type GitlabCredentialStatusManagerOptions = {
+// Type definition for GitLabCredentialStatusManager constructor method input
+export type GitLabCredentialStatusManagerOptions = {
   ownerAccountName: string;
   repoId: string;
   metaRepoId: string;
 } & BaseCredentialStatusManagerOptions;
 
-// Minimal set of options required for configuring GitlabCredentialStatusManager
+// Minimal set of options required for configuring GitLabCredentialStatusManager
 const GITLAB_MANAGER_REQUIRED_OPTIONS = [
   'ownerAccountName',
   'repoId',
   'metaRepoId'
 ].concat(BASE_MANAGER_REQUIRED_OPTIONS) as
-  Array<keyof GitlabCredentialStatusManagerOptions & BaseCredentialStatusManagerOptions>;
+  Array<keyof GitLabCredentialStatusManagerOptions & BaseCredentialStatusManagerOptions>;
 
 // Implementation of BaseCredentialStatusManager for GitLab
-export class GitlabCredentialStatusManager extends BaseCredentialStatusManager {
+export class GitLabCredentialStatusManager extends BaseCredentialStatusManager {
   private readonly ownerAccountName: string;
   private readonly repoId: string;
   private readonly metaRepoId: string;
   private repoClient: AxiosInstance;
   private metaRepoClient: AxiosInstance;
 
-  constructor(options: GitlabCredentialStatusManagerOptions) {
+  constructor(options: GitLabCredentialStatusManagerOptions) {
     const {
       ownerAccountName,
       repoName,
@@ -134,12 +135,12 @@ export class GitlabCredentialStatusManager extends BaseCredentialStatusManager {
   }
 
   // ensures proper configuration of GitLab status manager
-  ensureProperConfiguration(options: GitlabCredentialStatusManagerOptions): void {
+  ensureProperConfiguration(options: GitLabCredentialStatusManagerOptions): void {
     const missingOptions = [] as
-      Array<keyof GitlabCredentialStatusManagerOptions & BaseCredentialStatusManagerOptions>;
+      Array<keyof GitLabCredentialStatusManagerOptions & BaseCredentialStatusManagerOptions>;
 
     const isProperlyConfigured = GITLAB_MANAGER_REQUIRED_OPTIONS.every(
-      (option: keyof GitlabCredentialStatusManagerOptions) => {
+      (option: keyof GitLabCredentialStatusManagerOptions) => {
         if (!options[option]) {
           missingOptions.push(option as any);
         }
@@ -148,18 +149,20 @@ export class GitlabCredentialStatusManager extends BaseCredentialStatusManager {
     );
 
     if (!isProperlyConfigured) {
-      throw new Error(
-        'You have neglected to set the following required options for the ' +
-        'GitLab credential status manager: ' +
-        `${missingOptions.map(o => `'${o}'`).join(', ')}.`
-      );
+      throw new BadRequestError({
+        message:
+          'You have neglected to set the following required options for the ' +
+          'GitLab credential status manager: ' +
+          `${missingOptions.map(o => `"${o}"`).join(', ')}.`
+      });
     }
 
     if (this.didMethod === DidMethod.Web && !this.didWebUrl) {
-      throw new Error(
-        'The value of "didWebUrl" must be provided ' +
-        'when using "didMethod" of type "web".'
-      );
+      throw new BadRequestError({
+        message:
+          'The value of "didWebUrl" must be provided ' +
+          'when using "didMethod" of type "web".'
+      });
     }
   }
 
@@ -355,7 +358,9 @@ export class GitlabCredentialStatusManager extends BaseCredentialStatusManager {
   // creates data in status file
   async createStatusData(data: VerifiableCredential): Promise<void> {
     if (typeof data === 'string') {
-      throw new Error('This library does not support compact JWT credentials.');
+      throw new BadRequestError({
+        message: 'This library does not support compact JWT credentials.'
+      });
     }
     const statusCredentialId = deriveStatusCredentialId(data.id as string);
     const timestamp = getDateString();
@@ -399,7 +404,9 @@ export class GitlabCredentialStatusManager extends BaseCredentialStatusManager {
   // updates data in status file
   async updateStatusData(data: VerifiableCredential): Promise<void> {
     if (typeof data === 'string') {
-      throw new Error('This library does not support compact JWT credentials.');
+      throw new BadRequestError({
+        message: 'This library does not support compact JWT credentials.'
+      });
     }
     const statusCredentialId = deriveStatusCredentialId(data.id as string);
     const timestamp = getDateString();

--- a/src/credential-status-manager-gitlab.ts
+++ b/src/credential-status-manager-gitlab.ts
@@ -240,18 +240,21 @@ export class GitlabCredentialStatusManager extends BaseCredentialStatusManager {
   // checks if caller has authority to update status based on status repo access token
   async hasStatusAuthority(repoAccessToken: string, metaRepoAccessToken?: string): Promise<boolean> {
     this.resetClientAuthorization(repoAccessToken, metaRepoAccessToken);
+
     let hasRepoAccess = true;
-    let hasMetaRepoAccess = true;
     try {
       await this.readRepoData();
     } catch (error: any) {
       hasRepoAccess = false;
     }
+
+    let hasMetaRepoAccess = true;
     try {
       await this.readMetaRepoData();
     } catch (error: any) {
       hasMetaRepoAccess = false;
     }
+
     return hasRepoAccess && hasMetaRepoAccess;
   }
 

--- a/src/credential-status-manager-index.ts
+++ b/src/credential-status-manager-index.ts
@@ -95,15 +95,16 @@ export async function createStatusManager(options: CredentialStatusManagerOption
 
   // retrieve relevant data from status repo configuration
   const hasAccess = await statusManager.hasStatusAuthority(repoAccessToken, metaRepoAccessToken);
-  const reposExist = await statusManager.statusReposExist();
-  const reposEmpty = await statusManager.statusReposEmpty();
-
   if (!hasAccess) {
     throw new Error(`One or more of the access tokens you are using for the credential status repo ("${repoName}") and the credential status metadata repo ("${metaRepoName}") are incorrect or expired.`);
   }
+
+  const reposExist = await statusManager.statusReposExist();
   if (!reposExist) {
     throw new Error(`The credential status repo ("${repoName}") and the credential status metadata repo ("${metaRepoName}") must be manually created in advance.`);
   }
+
+  const reposEmpty = await statusManager.statusReposEmpty();
   if (!reposEmpty) {
     await statusManager.cleanupSnapshotData();
   } else {

--- a/src/credential-status-manager-index.ts
+++ b/src/credential-status-manager-index.ts
@@ -94,9 +94,13 @@ export async function createStatusManager(options: CredentialStatusManagerOption
   });
 
   // retrieve relevant data from status repo configuration
+  const hasAccess = await statusManager.hasStatusAuthority(repoAccessToken, metaRepoAccessToken);
   const reposExist = await statusManager.statusReposExist();
   const reposEmpty = await statusManager.statusReposEmpty();
 
+  if (!hasAccess) {
+    throw new Error(`One or more of the access tokens you are using for the credential status repo ("${repoName}") and the credential status metadata repo ("${metaRepoName}") are incorrect or expired.`);
+  }
   if (!reposExist) {
     throw new Error(`The credential status repo ("${repoName}") and the credential status metadata repo ("${metaRepoName}") must be manually created in advance.`);
   }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,25 +1,112 @@
-import { BaseCredentialStatusManager } from "./credential-status-manager-base";
+import { BaseCredentialStatusManager } from './credential-status-manager-base.js';
 
-interface StatusRepoInconsistencyErrorOptions {
+interface BaseErrorOptions {
+  statusManager?: BaseCredentialStatusManager;
+  message: string;
+}
+
+interface ChildErrorOptions {
+  statusManager?: BaseCredentialStatusManager;
+  message?: string;
+  defaultMessage: string;
+  label: string;
+}
+
+interface CustomErrorOptions {
   statusManager?: BaseCredentialStatusManager;
   message?: string;
 }
-export class StatusRepoInconsistencyError extends Error {
-  constructor(options?: StatusRepoInconsistencyErrorOptions) {
-    let statusManager, message;
-    if (!options) {
-      statusManager = undefined;
-      message = undefined;
-    } else {
-      ({ statusManager, message } = options);
-    }
-    const repoName = statusManager?.getRepoName() ?? "repoName";
-    const metaRepoName = statusManager?.getMetaRepoName() ?? "metaRepoName";
+
+class BaseError extends Error {
+  public statusManager: BaseCredentialStatusManager | undefined;
+  public message: string;
+
+  constructor(options: BaseErrorOptions) {
+    const { statusManager, message } = options;
+    super(message);
+    this.statusManager = statusManager;
+    this.message = message;
+  }
+}
+
+class ChildError extends BaseError {
+  constructor(options: ChildErrorOptions) {
+    const { statusManager, defaultMessage, label } = options;
+    const message = `[${label}] ${options?.message ?? defaultMessage}`;
+    super({ statusManager, message });
+  }
+}
+
+export class BadRequestError extends ChildError {
+  constructor(options?: CustomErrorOptions) {
+    const { statusManager, message } = options ?? {};
+    const defaultMessage = 'That is an invalid request.';
+    const label = 'BadRequestError';
+    super({ statusManager, message, defaultMessage, label });
+  }
+}
+
+export class NotFoundError extends ChildError {
+  constructor(options?: CustomErrorOptions) {
+    const { statusManager, message } = options ?? {};
+    const defaultMessage = 'Resource not found.';
+    const label = 'NotFoundError';
+    super({ statusManager, message, defaultMessage, label });
+  }
+}
+
+export class InvalidDidSeedError extends ChildError {
+  constructor(options?: CustomErrorOptions) {
+    const { statusManager, message } = options ?? {};
+    const defaultMessage = '"didSeed" must be a multibase-encoded value with at least 32 bytes.';
+    const label = 'InvalidDidSeedError';
+    super({ statusManager, message, defaultMessage, label });
+  }
+}
+
+export class InvalidTokenError extends ChildError {
+  constructor(options?: CustomErrorOptions) {
+    const { statusManager, message } = options ?? {};
+    const repoName = statusManager?.getRepoName() ?? 'repoName';
+    const metaRepoName = statusManager?.getMetaRepoName() ?? 'metaRepoName';
+    const defaultMessage = `One or more of the access tokens you are using for the ` +
+      `credential status repo ("${repoName}") and the ` +
+      `credential status metadata repo ("${metaRepoName}") are incorrect or expired.`;
+    const label = 'InvalidTokenError';
+    super({ statusManager, message, defaultMessage, label });
+  }
+}
+
+export class MissingRepositoryError extends ChildError {
+  constructor(options?: CustomErrorOptions) {
+    const { statusManager, message } = options ?? {};
+    const repoName = statusManager?.getRepoName() ?? 'repoName';
+    const metaRepoName = statusManager?.getMetaRepoName() ?? 'metaRepoName';
+    const defaultMessage = `The credential status repo ("${repoName}") and the ` +
+      `credential status metadata repo ("${metaRepoName}") must be manually created in advance.`
+    const label = 'MissingRepositoryError';
+    super({ statusManager, message, defaultMessage, label });
+  }
+}
+
+export class SnapshotExistsError extends ChildError {
+  constructor(options?: CustomErrorOptions) {
+    const { statusManager, message } = options ?? {};
+    const defaultMessage = 'Snapshot data already exists.';
+    const label = 'SnapshotExistsError';
+    super({ statusManager, message, defaultMessage, label });
+  }
+}
+
+export class InconsistentRepositoryError extends ChildError {
+  constructor(options?: CustomErrorOptions) {
+    const { statusManager, message } = options ?? {};
+    const repoName = statusManager?.getRepoName() ?? 'repoName';
+    const metaRepoName = statusManager?.getMetaRepoName() ?? 'metaRepoName';
     const defaultMessage = `Inconsistencies in the status repos may need to be manually resolved. ` +
       `If this is your first operation with this library (e.g., "createStatusManager"), please make sure that the ` +
       `credential status repo ("${repoName}") and the credential status metadata repo ("${metaRepoName}") are empty.`;
-    super(`StatusRepoInconsistencyError: ${message ?? defaultMessage}`);
-    // Set the prototype explicitly.
-    Object.setPrototypeOf(this, StatusRepoInconsistencyError.prototype);
+    const label = 'InconsistentRepositoryError';
+    super({ statusManager, message, defaultMessage, label });
   }
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,112 +1,91 @@
 import { BaseCredentialStatusManager } from './credential-status-manager-base.js';
 
-interface BaseErrorOptions {
-  statusManager?: BaseCredentialStatusManager;
-  message: string;
-}
-
-interface ChildErrorOptions {
+interface CustomErrorOptionalOptions {
   statusManager?: BaseCredentialStatusManager;
   message?: string;
+}
+
+interface CustomErrorRequiredOptions {
   defaultMessage: string;
-  label: string;
+  code: number;
 }
 
-interface CustomErrorOptions {
-  statusManager?: BaseCredentialStatusManager;
-  message?: string;
-}
+type CustomErrorOptions = CustomErrorOptionalOptions & CustomErrorRequiredOptions;
 
-class BaseError extends Error {
-  public statusManager: BaseCredentialStatusManager | undefined;
-  public message: string;
+class CustomError extends Error {
+  public code: number;
 
-  constructor(options: BaseErrorOptions) {
-    const { statusManager, message } = options;
+  constructor(options: CustomErrorOptions) {
+    const { defaultMessage, code } = options;
+    const message = `${options?.message ?? defaultMessage}`;
     super(message);
-    this.statusManager = statusManager;
-    this.message = message;
+    this.code = code;
   }
 }
 
-class ChildError extends BaseError {
-  constructor(options: ChildErrorOptions) {
-    const { statusManager, defaultMessage, label } = options;
-    const message = `[${label}] ${options?.message ?? defaultMessage}`;
-    super({ statusManager, message });
-  }
-}
-
-export class BadRequestError extends ChildError {
-  constructor(options?: CustomErrorOptions) {
-    const { statusManager, message } = options ?? {};
+export class BadRequestError extends CustomError {
+  constructor(options?: CustomErrorOptionalOptions) {
+    const { message } = options ?? {};
     const defaultMessage = 'That is an invalid request.';
-    const label = 'BadRequestError';
-    super({ statusManager, message, defaultMessage, label });
+    super({ message, defaultMessage, code: 400 });
   }
 }
 
-export class NotFoundError extends ChildError {
-  constructor(options?: CustomErrorOptions) {
-    const { statusManager, message } = options ?? {};
+export class NotFoundError extends CustomError {
+  constructor(options?: CustomErrorOptionalOptions) {
+    const { message } = options ?? {};
     const defaultMessage = 'Resource not found.';
-    const label = 'NotFoundError';
-    super({ statusManager, message, defaultMessage, label });
+    super({ message, defaultMessage, code: 404 });
   }
 }
 
-export class InvalidDidSeedError extends ChildError {
-  constructor(options?: CustomErrorOptions) {
-    const { statusManager, message } = options ?? {};
+export class InvalidDidSeedError extends CustomError {
+  constructor(options?: CustomErrorOptionalOptions) {
+    const { message } = options ?? {};
     const defaultMessage = '"didSeed" must be a multibase-encoded value with at least 32 bytes.';
-    const label = 'InvalidDidSeedError';
-    super({ statusManager, message, defaultMessage, label });
+    super({ message, defaultMessage, code: 400 });
   }
 }
 
-export class InvalidTokenError extends ChildError {
-  constructor(options?: CustomErrorOptions) {
+export class InvalidTokenError extends CustomError {
+  constructor(options?: CustomErrorOptionalOptions) {
     const { statusManager, message } = options ?? {};
     const repoName = statusManager?.getRepoName() ?? 'repoName';
     const metaRepoName = statusManager?.getMetaRepoName() ?? 'metaRepoName';
     const defaultMessage = `One or more of the access tokens you are using for the ` +
       `credential status repo ("${repoName}") and the ` +
       `credential status metadata repo ("${metaRepoName}") are incorrect or expired.`;
-    const label = 'InvalidTokenError';
-    super({ statusManager, message, defaultMessage, label });
+    super({ message, defaultMessage, code: 401 });
   }
 }
 
-export class MissingRepositoryError extends ChildError {
-  constructor(options?: CustomErrorOptions) {
+export class MissingRepositoryError extends CustomError {
+  constructor(options?: CustomErrorOptionalOptions) {
     const { statusManager, message } = options ?? {};
     const repoName = statusManager?.getRepoName() ?? 'repoName';
     const metaRepoName = statusManager?.getMetaRepoName() ?? 'metaRepoName';
     const defaultMessage = `The credential status repo ("${repoName}") and the ` +
       `credential status metadata repo ("${metaRepoName}") must be manually created in advance.`
-    const label = 'MissingRepositoryError';
-    super({ statusManager, message, defaultMessage, label });
+    super({ message, defaultMessage, code: 400 });
   }
 }
 
-export class SnapshotExistsError extends ChildError {
-  constructor(options?: CustomErrorOptions) {
-    const { statusManager, message } = options ?? {};
+export class SnapshotExistsError extends CustomError {
+  constructor(options?: CustomErrorOptionalOptions) {
+    const { message } = options ?? {};
     const defaultMessage = 'Snapshot data already exists.';
-    const label = 'SnapshotExistsError';
-    super({ statusManager, message, defaultMessage, label });
+    super({ message, defaultMessage, code: 400 });
   }
 }
 
-export class InconsistentRepositoryError extends ChildError {
-  constructor(options?: CustomErrorOptions) {
+export class InconsistentRepositoryError extends CustomError {
+  constructor(options?: CustomErrorOptionalOptions) {
     const { statusManager, message } = options ?? {};
     const repoName = statusManager?.getRepoName() ?? 'repoName';
     const metaRepoName = statusManager?.getMetaRepoName() ?? 'metaRepoName';
     const defaultMessage = `Inconsistencies in the status repos may need to be manually resolved. ` +
       `If this is your first operation with this library (e.g., "createStatusManager"), please make sure that the ` +
       `credential status repo ("${repoName}") and the credential status metadata repo ("${metaRepoName}") are empty.`;
-    const label = 'InconsistentRepositoryError';
-    super({ statusManager, message, defaultMessage, label });
+    super({ message, defaultMessage, code: 400 });
   }
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -11,6 +11,7 @@ import { VerifiableCredential } from '@digitalcredentials/vc-data-model';
 import * as DidKey from '@digitalcredentials/did-method-key';
 import * as DidWeb from '@interop/did-web-resolver';
 import { CryptoLD } from '@digitalcredentials/crypto-ld';
+import { BadRequestError, InvalidDidSeedError } from './errors.js';
 
 // Crypto library for linked data
 const cryptoLd = new CryptoLD();
@@ -101,10 +102,11 @@ export async function getSigningMaterial({
       }));
       break;
     default:
-      throw new Error(
-        '"didMethod" must be one of the following values: ' +
-        `${Object.values(DidMethod).map(v => `'${v}'`).join(', ')}.`
-      );
+      throw new BadRequestError({
+        message:
+          '"didMethod" must be one of the following values: ' +
+          `${Object.values(DidMethod).map(m => `"${m}"`).join(', ')}.`
+      });
   }
   const issuerDid = didDocument.id;
   const verificationMethod = extractId(didDocument.assertionMethod[0]);
@@ -132,17 +134,17 @@ function decodeBase64AsAscii(text: string): string {
 }
 
 // decodes DID seed
-function decodeSeed(secretKeySeed: string): Uint8Array {
-  let secretKeySeedBytes;
-  if (secretKeySeed.startsWith('z')) {
+function decodeSeed(didSeed: string): Uint8Array {
+  let didSeedBytes;
+  if (didSeed.startsWith('z')) {
     // This is a multibase-encoded seed
-    secretKeySeedBytes = decodeSecretKeySeed({secretKeySeed});
-  } else if (secretKeySeed.length >= 32) {
-      secretKeySeedBytes = (new TextEncoder()).encode(secretKeySeed).slice(0, 32);
+    didSeedBytes = decodeSecretKeySeed({ secretKeySeed: didSeed });
+  } else if (didSeed.length >= 32) {
+      didSeedBytes = (new TextEncoder()).encode(didSeed).slice(0, 32);
   } else {
-    throw Error('"secretKeySeed" must be a multibase-encoded value with at least 32 bytes');
+    throw new InvalidDidSeedError();
   }
-  return secretKeySeedBytes;
+  return didSeedBytes;
 }
 
 // extracts ID from object or string
@@ -154,11 +156,11 @@ function extractId(objectOrString: any): string {
 }
 
 // derives abbreviated ID from status credential URL
-export const deriveStatusCredentialId = (statusCredentialUrl: string): string => {
+export function deriveStatusCredentialId(statusCredentialUrl: string): string {
   return statusCredentialUrl.split('/').slice(-1).pop() as string;
-};
+}
 
 // retrieves current timestamp
 export function getDateString(): string {
   return (new Date()).toISOString();
-};
+}

--- a/test/credential-status-manager-github.spec.ts
+++ b/test/credential-status-manager-github.spec.ts
@@ -72,7 +72,7 @@ class MockGithubCredentialStatusManager extends GithubStatus.GithubCredentialSta
   async deployCredentialStatusWebsite(): Promise<void> {}
 
   // checks if caller has authority to update status based on status repo access token
-  async hasStatusAuthority(repoAccessToken: string): Promise<boolean> { return true; }
+  async hasStatusAuthority(repoAccessToken: string, metaRepoAccessToken?: string): Promise<boolean> { return true; }
 
   // checks if status repos exist
   async statusReposExist(): Promise<boolean> { return true; }

--- a/test/credential-status-manager-github.spec.ts
+++ b/test/credential-status-manager-github.spec.ts
@@ -14,7 +14,7 @@ import {
   CredentialStatusManagerService,
   CredentialStatusSnapshotData
 } from '../src/credential-status-manager-base.js';
-import * as GithubStatus from '../src/credential-status-manager-github.js';
+import * as GitHubStatus from '../src/credential-status-manager-github.js';
 import {
   checkLocalCredentialStatus,
   checkRemoteCredentialStatus,
@@ -34,12 +34,12 @@ import {
 
 const sandbox = createSandbox();
 
-class MockGithubCredentialStatusManager extends GithubStatus.GithubCredentialStatusManager {
+class MockGitHubCredentialStatusManager extends GitHubStatus.GitHubCredentialStatusManager {
   private statusCredential: VerifiableCredential;
   private config: CredentialStatusConfigData;
   private snapshot: CredentialStatusSnapshotData;
 
-  constructor(options: GithubStatus.GithubCredentialStatusManagerOptions) {
+  constructor(options: GitHubStatus.GitHubCredentialStatusManagerOptions) {
     const {
       ownerAccountName,
       repoName,
@@ -155,9 +155,9 @@ class MockGithubCredentialStatusManager extends GithubStatus.GithubCredentialSta
 
 describe('GitHub Credential Status Manager', () => {
   const service = 'github' as CredentialStatusManagerService;
-  let statusManager: GithubStatus.GithubCredentialStatusManager;
+  let statusManager: GitHubStatus.GitHubCredentialStatusManager;
   sandbox.stub(OctokitClient.Octokit.prototype, 'constructor').returns(null);
-  sandbox.stub(GithubStatus, 'GithubCredentialStatusManager').value(MockGithubCredentialStatusManager);
+  sandbox.stub(GitHubStatus, 'GitHubCredentialStatusManager').value(MockGitHubCredentialStatusManager);
 
   beforeEach(async () => {
     statusManager = await createStatusManager({
@@ -169,12 +169,12 @@ describe('GitHub Credential Status Manager', () => {
       metaRepoAccessToken,
       didMethod,
       didSeed
-    }) as GithubStatus.GithubCredentialStatusManager;
+    }) as GitHubStatus.GitHubCredentialStatusManager;
   });
 
   it('tests output of createStatusManager', async () => {
     expect(statusManager).to.be.instanceof(BaseCredentialStatusManager);
-    expect(statusManager).to.be.instanceof(GithubStatus.GithubCredentialStatusManager);
+    expect(statusManager).to.be.instanceof(GitHubStatus.GitHubCredentialStatusManager);
   });
 
   it('tests allocateStatus', async () => {

--- a/test/credential-status-manager-gitlab.spec.ts
+++ b/test/credential-status-manager-gitlab.spec.ts
@@ -78,7 +78,7 @@ class MockGitlabCredentialStatusManager extends GitlabStatus.GitlabCredentialSta
   async deployCredentialStatusWebsite(): Promise<void> {}
 
   // checks if caller has authority to update status based on status repo access token
-  async hasStatusAuthority(repoAccessToken: string): Promise<boolean> { return true; }
+  async hasStatusAuthority(repoAccessToken: string, metaRepoAccessToken?: string): Promise<boolean> { return true; }
 
   // checks if status repos exist
   async statusReposExist(): Promise<boolean> { return true; }

--- a/test/credential-status-manager-gitlab.spec.ts
+++ b/test/credential-status-manager-gitlab.spec.ts
@@ -14,7 +14,7 @@ import {
   CredentialStatusManagerService,
   CredentialStatusSnapshotData
 } from '../src/credential-status-manager-base.js';
-import * as GitlabStatus from '../src/credential-status-manager-gitlab.js';
+import * as GitLabStatus from '../src/credential-status-manager-gitlab.js';
 import {
   checkLocalCredentialStatus,
   checkRemoteCredentialStatus,
@@ -36,12 +36,12 @@ import {
 
 const sandbox = createSandbox();
 
-class MockGitlabCredentialStatusManager extends GitlabStatus.GitlabCredentialStatusManager {
+class MockGitLabCredentialStatusManager extends GitLabStatus.GitLabCredentialStatusManager {
   private statusCredential: VerifiableCredential;
   private config: CredentialStatusConfigData;
   private snapshot: CredentialStatusSnapshotData;
 
-  constructor(options: GitlabStatus.GitlabCredentialStatusManagerOptions) {
+  constructor(options: GitLabStatus.GitLabCredentialStatusManagerOptions) {
     const {
       ownerAccountName,
       repoName,
@@ -161,9 +161,9 @@ class MockGitlabCredentialStatusManager extends GitlabStatus.GitlabCredentialSta
 
 describe('GitLab Credential Status Manager', () => {
   const service = 'gitlab' as CredentialStatusManagerService;
-  let statusManager: GitlabStatus.GitlabCredentialStatusManager;
+  let statusManager: GitLabStatus.GitLabCredentialStatusManager;
   sandbox.stub(AxiosClient.default, 'create').returnsThis();
-  sandbox.stub(GitlabStatus, 'GitlabCredentialStatusManager').value(MockGitlabCredentialStatusManager);
+  sandbox.stub(GitLabStatus, 'GitLabCredentialStatusManager').value(MockGitLabCredentialStatusManager);
 
   beforeEach(async () => {
     statusManager = await createStatusManager({
@@ -177,12 +177,12 @@ describe('GitLab Credential Status Manager', () => {
       metaRepoAccessToken,
       didMethod,
       didSeed
-    }) as GitlabStatus.GitlabCredentialStatusManager;
+    }) as GitLabStatus.GitLabCredentialStatusManager;
   });
 
   it('tests output of createStatusManager', async () => {
     expect(statusManager).to.be.instanceof(BaseCredentialStatusManager);
-    expect(statusManager).to.be.instanceof(GitlabStatus.GitlabCredentialStatusManager);
+    expect(statusManager).to.be.instanceof(GitLabStatus.GitLabCredentialStatusManager);
   });
 
   it('tests allocateStatus', async () => {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -76,7 +76,7 @@ export function checkLocalCredentialStatus(
   expect(credentialWithStatus.credentialStatus).to.have.property('statusListCredential');
   expect(credentialWithStatus.credentialStatus.type).to.equal('StatusList2021Entry');
   expect(credentialWithStatus.credentialStatus.statusPurpose).to.equal('revocation');
-  expect(credentialWithStatus.credentialStatus.statusListIndex).to.equal(credentialStatusIndex);
+  expect(credentialWithStatus.credentialStatus.statusListIndex).to.equal(credentialStatusIndex.toString());
   expect(credentialWithStatus.credentialStatus.id.startsWith(statusCredentialUrl)).to.be.true;
   expect(credentialWithStatus.credentialStatus.statusListCredential.startsWith(statusCredentialUrl)).to.be.true;
 }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -61,10 +61,10 @@ export function checkLocalCredentialStatus(
 ) {
   let statusCredentialUrl;
   switch (service) {
-    case CredentialStatusManagerService.Github:
+    case CredentialStatusManagerService.GitHub:
       statusCredentialUrl = `https://${ownerAccountName}.github.io/${repoName}/${statusCredentialId}`;
       break;
-    case CredentialStatusManagerService.Gitlab:
+    case CredentialStatusManagerService.GitLab:
       statusCredentialUrl = `https://${ownerAccountName}.gitlab.io/${repoName}/${statusCredentialId}`;
       break;
   }
@@ -109,10 +109,10 @@ export function checkStatusCredential(
 ) {
   let statusCredentialUrl;
   switch (service) {
-    case CredentialStatusManagerService.Github:
+    case CredentialStatusManagerService.GitHub:
       statusCredentialUrl = `https://${ownerAccountName}.github.io/${repoName}/${statusCredentialId}`;
       break;
-    case CredentialStatusManagerService.Gitlab:
+    case CredentialStatusManagerService.GitLab:
       statusCredentialUrl = `https://${ownerAccountName}.gitlab.io/${repoName}/${statusCredentialId}`;
       break;
   }


### PR DESCRIPTION
This PR addresses Issue #16 by checking a client's authority to manage status repos during initialization and reporting an error message to the caller if not.